### PR TITLE
tags: Callsign in detailed tag not CJI filtered (TopSky profiles)

### DIFF
--- a/UK/Data/Settings/Tags.txt
+++ b/UK/Data/Settings/Tags.txt
@@ -214,7 +214,7 @@ TAGITEM:119::0:0:0:0:TopSky plugin:0:0:::1
 TAGITEM:108::0:1:9005:9006:UK Controller Plugin:0:1:UK Controller Plugin:UK Controller Plugin:1
 TAGITEM:111::0:1:9006:9006:UK Controller Plugin:0:1:UK Controller Plugin:UK Controller Plugin:1
 TAGITEM:33::0:0:0:0::0:0:::1
-TAGITEM:22::1:0:6:39:TopSky plugin:0:1:TopSky plugin:TopSky plugin:8
+TAGITEM:9::1:0:6:39::0:1:TopSky plugin:TopSky plugin:8
 TAGITEM:1: :0:0:0:0::0:1:::1
 TAGITEM:58::0:0:32:0:TopSky plugin:0:1:::1
 TAGITEM:0::0:0:0:0::0:1:::1


### PR DESCRIPTION
Fixes #48

# Summary of changes

Callsign item moved to vanilla style item, this requires testing to ensure we don;t lose any Topsky functionality.

# Screenshots (if necessary)

Nil
