### PR TITLE
Fixes #226 - Amended Jersey Approach and Radar Voice Channels

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2021/09 to 2021/13
+1. Bug - Swapped Jersey Approach and Radar Voice Channels - thanks to @danielbutton (Daniel Button)
+
 # Changes from release 2021/07 to 2021/09
 1. AIRAC - Heathrow SMAA (MSAW) Amended - thanks to @luke11brown (Luke Brown)
 2. Enhancement - VATCANBookings plugin updated to V1.1 - thanks to @luke11brown (Luke Brown)

--- a/UK/Data/Settings/Voice.txt
+++ b/UK/Data/Settings/Voice.txt
@@ -115,8 +115,8 @@ AG:EGJB_GND:121.800:old.voice.notused:egjb_gnd
 AG:EGJB_ATIS:118.900:old.voice.notused:egjb_atis
 AG:EGJJ_C_APP:125.200:old.voice.notused:egjj_c_app
 AG:EGJJ_S_APP:120.450:old.voice.notused:egjj_s_app
-AG:EGJJ_APP:118.550:old.voice.notused:egjj_app
-AG:EGJJ_A_APP:120.300:old.voice.notused:egjj_a_app
+AG:EGJJ_APP:120.300:old.voice.notused:egjj_app
+AG:EGJJ_F_APP:118.550:old.voice.notused:egjj_f_app
 AG:EGJJ_TWR:119.450:old.voice.notused:egjj_twr
 AG:EGJJ_GND:121.900:old.voice.notused:egjj_gnd
 AG:EGJJ_ATIS:134.670:old.voice.notused:egjj_atis


### PR DESCRIPTION
Fixes #226 

# Summary of changes

Voice entries amended so correct frequency is used for both positions as per Sector File:

EGJJ_APP (Jersey Approach) ~~118.550~~ -> **120.300**
EGJJ_F_APP (Jersey Radar) ~~120.300~~ -> **118.550**

# Screenshots (if necessary)

N/A
