### PR TITLE
Remove .vs and correct gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@
 *.sqlite
 *.suo
 *.sqlite-journal
-/.vs/ProjectSettings.json
-/.vs/VSWorkspaceState.json
-/ipaddr.txt
+.vs/*
+ipaddr.txt

--- a/.vs/ProjectSettings.json
+++ b/.vs/ProjectSettings.json
@@ -1,3 +1,0 @@
-{
-  "CurrentProjectSetting": null
-}


### PR DESCRIPTION
.vs is an autogenerated folder by VS not intended to be shared.
This usually would have been ignored by the .gitignore but that was pathed wrong.
Both are fixed by this PR.