### PR TITLE
Fixes #332 - Update aliases

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,5 @@
+x. Enhancement - Updated aliases - thanks to @PLM1995 (Peter Mooney)
+
 # Changes from release 2022/09 to 2022/10
 1. AIRAC (2210) - Area minimum altitudes revised - thanks to @MikePikeCollab (Mike Pike)
 2. Enhancement - TopSky updated to version 2.4.1 - thanks to @luke11brown (Luke Brown)

--- a/UK/Data/Alias/AC_Alias.txt
+++ b/UK/Data/Alias/AC_Alias.txt
@@ -1,6 +1,6 @@
 ========================================================
 Alias:    	    UK
-Last Updated:	2022-03-29
+Last Updated:	2022-11-29
 ========================================================
 
 ========================================================
@@ -10,8 +10,8 @@ Generic
 .v Can you receive voice?
 .std Check Standard Pressure is set (1013 hPa)
 
-.sec You can check coverage at https://vats.im/uksectors/
-.cov You can check coverage at https://vats.im/uksectors/
+.sec You can check coverage at https://vatglasses.uk/ukireland/
+.cov You can check coverage at https://vatglasses.uk/ukireland/
 .charts Charts relevant to your flight can be found at https://chartfox.org/$1/
 
 .rsn Report your stand number
@@ -51,7 +51,7 @@ Handoffs
 .mon Monitor $radioname($1) ($atccallsign($1)) $freq($1)
 
 .uni No Further ATC available. Monitor Unicom 122.800
-.oma You are currently outside my airspace. Monitor Unicom 122.800. (Please see https://vats.im/uksectors/)
+.oma You are currently outside my airspace. Monitor Unicom 122.800. (Please see https://vatglasses.uk/ukireland/)
 .nso $1 is offline - monitor unicom 122.800
 
 ========================================================
@@ -77,6 +77,8 @@ Vertical
 .sicnta Squawk Ident, climb now to altitude $1ft
 .sicna Squawk Ident, climb now to altitude $1ft
 .sima Squawk Ident, maintain altitude $alt
+
+.rrl Report your requested level
 
 .cta Climb to altitude $1ft
 .cnta Climb now to altitude $1ft
@@ -223,7 +225,9 @@ Arrival
 .stararr $star arrival, $arr
 .stararrrw $star arrival, $arr landing runway $arrrwy($arr)
 .starrw $star arrival, landing runway $arrrwy($arr)
-.hold Hold at $1, delay $2 minutes
+.hold Hold at $1, $2 hand turns, as published. Delay $3 minutes
+.holdl Hold at $1, left hand turns, as published. Delay $2 minutes
+.holdr Hold at $1, right hand turns, as published. Delay $2 minutes
 .holdd Hold at $1, delay $2 minutes. The inbound course is $3, $4 hand, $5 minute legs, speed $6 knots
 
 ========================================================

--- a/UK/Data/Alias/Heathrow_Alias.txt
+++ b/UK/Data/Alias/Heathrow_Alias.txt
@@ -1,7 +1,7 @@
 ========================================================
 Alias:    	Heathrow
 Created:     	2016-03-31
-Last Updated:	2016-03-31
+Last Updated:	2022-11-29
 ========================================================
 
 ========================================================
@@ -211,13 +211,15 @@ Approach Radar
 Hold and FIS
 ========================================================
 
-.hold Hold at $1, delay $2 minutes
+.hold Hold at $1, $2 hand turns, as published. Delay $3 minutes
+.holdl Hold at $1, left hand turns, as published. Delay $2 minutes
+.holdr Hold at $1, right hand turns, as published. Delay $2 minutes
 .holdd Hold at $1, delay $2 minutes. The inbound course is $3, $4 minute legs, speed $5 knots
 
-.hbnn Hold at BNN. Delay is $1 minutes. The BNN hold is 118 inbound, right hand turns, 1 minute legs, speed 220kts
-.hlam Hold at LAM. Delay is $1 minutes. The LAM hold is 265 inbound, left hand turns, 1 minute legs, speed 220kts
-.hock Hold at OCK. Delay is $1 minutes. The OCK hold is 330 inbound, right hand turns, 1 minute legs, speed 220kts
-.hbig Hold at BIG. Delay is $1 minutes. The BIG hold is 303 inbound, right hand turns, 1 minute legs, speed 220kts
+.hbnn Hold at BNN. Delay is $1 minutes. The BNN hold is 116 inbound, right hand turns, 1 minute legs, speed 220kts
+.hlam Hold at LAM. Delay is $1 minutes. The LAM hold is 263 inbound, left hand turns, 1 minute legs, speed 220kts
+.hock Hold at OCK. Delay is $1 minutes. The OCK hold is 328 inbound, right hand turns, 1 minute legs, speed 220kts
+.hbig Hold at BIG. Delay is $1 minutes. The BIG hold is 302 inbound, right hand turns, 1 minute legs, speed 220kts
 
 .bs Basic service
 .ts Traffic service


### PR DESCRIPTION
Fixes #332

# Summary of changes

- Holding phraseology ammended per forum post (in both AC and Heathrow alias files).
- Heathrow hold inbound headings updated for magnetic variation since 2016 (in Heathrow alias file).
- Sector info link updated to VatGlasses (in AC alias file).
- Report Requested Level alias added (in AC alias file).
