### PR TITLE
lists: Fixed prenote column for TC profiles

### DIFF
--- a/UK/Data/Settings/Lists.txt
+++ b/UK/Data/Settings/Lists.txt
@@ -85,7 +85,7 @@ m_Column:RFL:4:1:22:30:30:1::::3:0.0
 m_Column:NFREQ:7:0:107:0:0:0:UK Controller Plugin:::1:0.0
 m_Column:RLS:3:1:124:9012:9015:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column::6:0:125:9014:9014:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
-m_Column:PRE:3:1:9:9017:9018:1::UK Controller Plugin:UK Controller Plugin:1:0.0
+m_Column:PRE:3:1:127:9017:9018:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 END
 ARR
 m_Visible:0


### PR DESCRIPTION
TC profiles were showing the callsign in the prenote column - now fixed