### PR TITLE
Fixes #504 - Fix ATIS frequencies in Essex Profiles

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-1. Bug - Fixed controller atises for 8.33 Trial - thanks to @kye-taylor (Kye Taylor)
+1. Bug - Fixed ATIS frequencies in Essex Profiles for 8.33 Trial - thanks to @kye-taylor (Kye Taylor)
 
 # Changes from release 2023/08 to 2023/09
 1. Bug - vATIS files EGKK frequency corrected - thanks to @luke11brown (Luke Brown)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,5 @@
+1. Bug - Fixed controller atises for 8.33 Trial - thanks to @kye-taylor (Kye Taylor)
+
 # Changes from release 2023/08 to 2023/09
 1. Bug - vATIS files EGKK frequency corrected - thanks to @luke11brown (Luke Brown)
 2. Bug - Update TopSky clearance item in departure list to use new DCL Window - thanks to @luke11brown (Luke Brown)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,4 @@
+# Changes from release 2023/09 to 2023/10
 1. Bug - Fixed ATIS frequencies in Essex Profiles for 8.33 Trial - thanks to @kye-taylor (Kye Taylor)
 
 # Changes from release 2023/08 to 2023/09

--- a/UK/Data/Settings/Local/Essex/Essex_Profiles.txt
+++ b/UK/Data/Settings/Local/Essex/Essex_Profiles.txt
@@ -1,27 +1,27 @@
 PROFILE
 PROFILE:ESSEX_APP:100:5
 ATIS2:Stansted Radar | EGSS, EGGW and EGSC Top-Down
-ATIS3:Stansted Voice ATIS on 127.175
+ATIS3:Stansted Voice ATIS on 127.180
 ATIS4:Submit feedback at vats.im/atcfb
 PROFILE:EGSS_DEL:10:2
 ATIS2:Stansted Delivery
-ATIS3:Voice ATIS on 127.175
+ATIS3:Voice ATIS on 127.180
 ATIS4:Submit feedback at vats.im/atcfb
 PROFILE:EGSS_GND:20:3
 ATIS2:Stansted Ground
-ATIS3:Voice ATIS on 127.175
+ATIS3:Voice ATIS on 127.180
 ATIS4:Submit feedback at vats.im/atcfb
 PROFILE:EGSS_TWR:50:4
 ATIS2:Stansted Tower
-ATIS3:Voice ATIS on 127.175
+ATIS3:Voice ATIS on 127.180
 ATIS4:Submit feedback at vats.im/atcfb
 PROFILE:EGSS_F_APP:75:5
 ATIS2:Stansted Director
-ATIS3:Voice ATIS on 127.175
+ATIS3:Voice ATIS on 127.180
 ATIS4:Submit feedback at vats.im/atcfb
 PROFILE:EGSS_APP:100:5
 ATIS2:Stansted Radar
-ATIS3:Voice ATIS on 127.175
+ATIS3:Voice ATIS on 127.180
 ATIS4:Submit feedback at vats.im/atcfb
 PROFILE:EGGW_TWR:50:4
 ATIS2:Luton Tower 


### PR DESCRIPTION
Fixes #504 

# Summary of changes

Checked ATIS across AD 8.33 Trial.
ESSEX needed an update.

# Screenshots (if necessary)

N/A