### PR TITLE
Fixes #537 - GitHub automation to package zip file on release publish

### DIFF
--- a/.github/workflows/Create ZIP on release.yml
+++ b/.github/workflows/Create ZIP on release.yml
@@ -3,10 +3,11 @@ name: Create ZIP on Release
 on:
   release:
     types:
-      - created
+      - published
+  workflow_dispatch:
 
 jobs:
-  package:
+  Create ZIP on release:
     runs-on: ubuntu-latest
 
     steps:
@@ -15,7 +16,7 @@ jobs:
 
       - name: Copy README from docs folder
         run: |
-          cp \_docs\README.pdf UK\README.pdf
+          cp _docs/README.pdf UK/README.pdf
 
       - name: Get Release Tag
         id: get_release_tag
@@ -24,10 +25,12 @@ jobs:
 
       - name: Package Folder as ZIP
         run: |
-          zip -r "uk_controller_pack_${{ steps.get_release_tag.outputs.tag }}.zip" \UK\ -x "*.py"
+          zip -r "uk_controller_pack_${{ steps.get_release_tag.outputs.tag }}.zip" UK/ -x "*.py"
           
-      - name: Upload ZIP Artifact
-        uses: actions/upload-artifact@v2
+      - name: Upload ZIP as Release Asset
+        uses: softprops/action-gh-release@v1
         with:
-          name: my-package
-          path: "uk_controller_pack_${{ steps.get_release_tag.outputs.tag }}.zip"
+          files: |
+            uk_controller_pack_${{ steps.get_release_tag.outputs.tag }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Create ZIP on release.yml
+++ b/.github/workflows/Create ZIP on release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  Create ZIP on release:
+  package:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/Create ZIP on release.yml
+++ b/.github/workflows/Create ZIP on release.yml
@@ -1,0 +1,33 @@
+name: Create ZIP on Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Copy README from docs folder
+        run: |
+          cp \_docs\README.pdf UK\README.pdf
+
+      - name: Get Release Tag
+        id: get_release_tag
+        run: |
+          echo "::set-output name=tag::${{ github.event.release.tag_name }}"
+
+      - name: Package Folder as ZIP
+        run: |
+          zip -r "uk_controller_pack_${{ steps.get_release_tag.outputs.tag }}.zip" \UK\ -x "*.py"
+          
+      - name: Upload ZIP Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: my-package
+          path: "uk_controller_pack_${{ steps.get_release_tag.outputs.tag }}.zip"


### PR DESCRIPTION
Fixes #537

# Summary of changes
GitHub workflow to create zip file on release publish. Can be simply uploaded to forum for release

Tested working on
https://github.com/luke11brown/uk-controller-pack/releases/tag/2023_09i

# Screenshots (if necessary)
Nil
