### PR TITLE
Spelling mistake in Github README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 # Welcome
-The UK (EGTT and EGPX FIRs) controller pack provides the tools to VATSIM UK controllers to control relistically, efficiently and easily on the VATSIM network
+The UK (EGTT and EGPX FIRs) controller pack provides the tools to VATSIM UK controllers to control realistically, efficiently and easily on the VATSIM network
 
 A new release will be published in line with each AIRAC cycle (as long as significant changes warrant such a release).
 


### PR DESCRIPTION
Haven't created an issue for such a minor fix, but can do if required...

# Summary of changes

Spelt relistically rather than realistically

# Screenshots (if necessary)

![image](https://github.com/VATSIM-UK/uk-controller-pack/assets/67550533/df15ba1a-909e-4941-a24d-0c79e1c5945d)