### PR TITLE
Fixes #666 - Add Leeds Radar Gate to appropriate displays

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2024/03 to 2024/04
+1. Enhancement - Enabled Leeds Radar Gate on profiles - thanks to @SamLefevre (Samuel Lefevre)
+
 # Changes from release 2024/01 to 2024/03
 1. Bug - Fix Edinburgh extended centreline - thanks to @SamLefevre (Samuel Lefevre)
 2. Enhancement (TopSky) - Added additional scale markers (graticules) and Clacton radar monitored routes - thanks to @hazzas-99
@@ -7,7 +10,6 @@
 6. Bug - EGPA (Kirkwall) ATIS frequency fixed - thanks to @luke11brown (Luke Brown)
 7. Bug - Generic profiles missing file added  - thanks to @luke11brown (Luke Brown)
 8. Enhancement - Ground Status right click actions in lists amended - thanks to @luke11brown (Luke Brown)
-x. Enhancement - Enabled Leeds Radar Gate on profiles - thanks to @SamLefevre (Samuel Lefevre)
 
 # Changes from release 2023/13 to 2024/01
 1. Bug - Corrected Denham (EGLD) Frequency - thanks to @AliceFord (Alice Ford)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 6. Bug - EGPA (Kirkwall) ATIS frequency fixed - thanks to @luke11brown (Luke Brown)
 7. Bug - Generic profiles missing file added  - thanks to @luke11brown (Luke Brown)
 8. Enhancement - Ground Status right click actions in lists amended - thanks to @luke11brown (Luke Brown)
+x. Enhancement - Enabled Leeds Radar Gate on profiles - thanks to @SamLefevre (Samuel Lefevre)
 
 # Changes from release 2023/13 to 2024/01
 1. Bug - Corrected Denham (EGLD) Frequency - thanks to @AliceFord (Alice Ford)

--- a/UK/Data/ASR/Leeds/Leeds Radar_1.asr
+++ b/UK/Data/ASR/Leeds/Leeds Radar_1.asr
@@ -576,6 +576,7 @@ Runways:EGNM Leeds Bradford 14-32:extended centerline 2
 Runways:EGNM Leeds Bradford 14-32:extended centerline 2 left ticks
 Runways:EGNM Leeds Bradford 14-32:extended centerline 2 right ticks
 Sids:EGNM Leeds Bradford SMAA:
+Stars:Leeds Bradford Gates:
 Stars:Leeds Delegation Line:
 Stars:POL - LBA Line:
 SHOWC:1

--- a/UK/Data/ASR/Leeds/Leeds Radar_2.asr
+++ b/UK/Data/ASR/Leeds/Leeds Radar_2.asr
@@ -1667,6 +1667,7 @@ Runways:EGNM Leeds Bradford 14-32:extended centerline 2
 Runways:EGNM Leeds Bradford 14-32:extended centerline 2 left ticks
 Runways:EGNM Leeds Bradford 14-32:extended centerline 2 right ticks
 Sids:EGNM Leeds Bradford SMAA:
+Stars:Leeds Bradford Gates:
 Stars:Leeds Delegation Line:
 Stars:POL - LBA Line:
 VORs:ABB:symbol

--- a/UK/Data/ASR/Leeds/Leeds Radar_3.asr
+++ b/UK/Data/ASR/Leeds/Leeds Radar_3.asr
@@ -2051,6 +2051,7 @@ Runways:EGNM Leeds Bradford 14-32:extended centerline 2
 Runways:EGNM Leeds Bradford 14-32:extended centerline 2 left ticks
 Runways:EGNM Leeds Bradford 14-32:extended centerline 2 right ticks
 Sids:EGNM Leeds Bradford SMAA:
+Stars:Leeds Bradford Gates:
 Stars:Leeds Delegation Line:
 Stars:POL - LBA Line:
 VORs:ABB:symbol

--- a/UK/Data/ASR/Leeds/Leeds Radar_4.asr
+++ b/UK/Data/ASR/Leeds/Leeds Radar_4.asr
@@ -3347,6 +3347,7 @@ Runways:EGNM Leeds Bradford 14-32:extended centerline 2
 Runways:EGNM Leeds Bradford 14-32:extended centerline 2 left ticks
 Runways:EGNM Leeds Bradford 14-32:extended centerline 2 right ticks
 Sids:EGNM Leeds Bradford SMAA:
+Stars:Leeds Bradford Gates:
 Stars:Leeds Delegation Line:
 Stars:POL - LBA Line:
 VORs:ABB:name

--- a/UK/Data/ASR/MPC/PC1.asr
+++ b/UK/Data/ASR/MPC/PC1.asr
@@ -334,6 +334,7 @@ Sids:PC Southeast:
 Sids:PC West:
 Stars:DEXEN Buffer:
 Stars:HON Gate:
+Stars:Leeds Bradford Gates:
 Stars:Leeds Delegation Line:
 Stars:Manchester RMA Westerlies:
 Stars:POL - LBA Line:

--- a/UK/Data/ASR/MPC/PC2.asr
+++ b/UK/Data/ASR/MPC/PC2.asr
@@ -1425,6 +1425,7 @@ Sids:PC Southeast:
 Sids:PC West:
 Stars:DEXEN Buffer:
 Stars:HON Gate:
+Stars:Leeds Bradford Gates:
 Stars:Leeds Delegation Line:
 Stars:Manchester RMA Westerlies:
 Stars:POL - LBA Line:

--- a/UK/Data/ASR/MPC/PC3.asr
+++ b/UK/Data/ASR/MPC/PC3.asr
@@ -2060,6 +2060,7 @@ Sids:PC Southeast:
 Sids:PC West:
 Stars:DEXEN Buffer:
 Stars:HON Gate:
+Stars:Leeds Bradford Gates:
 Stars:Leeds Delegation Line:
 Stars:Manchester RMA Westerlies:
 Stars:POL - LBA Line:

--- a/UK/Data/ASR/MPC/PC4.asr
+++ b/UK/Data/ASR/MPC/PC4.asr
@@ -3342,6 +3342,8 @@ Fixes:ZORFE:symbol
 Geo:Coastline (Medium Detail) GB Main Coastline:
 Geo:Extended centrelines:
 Stars:Heathrow RMA Westerlies:
+Stars:Leeds Bradford Gates:
+Stars:Leeds Delegation Line:
 Stars:Luton RMA:
 Stars:Manchester RMA Westerlies:
 Stars:Stansted RMA:

--- a/UK/Data/Settings/Local/Leeds/APP_Symbology.txt
+++ b/UK/Data/Settings/Local/Leeds/APP_Symbology.txt
@@ -9,7 +9,7 @@ High airways:name:2512998:3.5:0:0:8
 Fixes:symbol:11248794:1.0:0:0:7
 Fixes:name:11248794:3.2:0:0:2
 Sids:line:11248794:3.0:0:0:7
-Stars:line:11248794:3.0:1:0:7
+Stars:line:0:3.0:0:0:7
 ARTCC high boundary:line:1315860:3.0:0:1:7
 ARTCC boundary:line:1976520:3.0:0:0:7
 ARTCC low boundary:line:1315860:3.0:0:1:7
@@ -77,7 +77,7 @@ Other:conflict warning:65535:3.5:0:2:7
 Other:conflict detected:255:3.5:0:2:7
 Other:route annotation:16777215:3.0:0:1:7
 Other:freetext:2631720:3.5:0:0:7
-Other:range rings:1315860:5.0:1:0:2
+Other:range rings:1315860:5.0:2:0:2
 Other:off antenna range rings:255:5.0:0:0:2
 Other:plane range rings:10855845:5.0:0:0:2
 Other:manual taxi line:16777215:5.0:0:3:2


### PR DESCRIPTION
Fixes #666

# Summary of changes

Enable the gate on Leeds display and PC display

# Screenshots (if necessary)

![image](https://github.com/VATSIM-UK/uk-controller-pack/assets/64741876/f5022e9f-1c16-42cf-b4a0-5d3594d63bf2)
![image](https://github.com/VATSIM-UK/uk-controller-pack/assets/64741876/c72213e8-7e2d-4c40-89a7-73d1e0a9f919)

