### PR TITLE
Fixes #694 - Fixed vATIS transition levels (EGHC)

### DIFF
--- a/UK/vATIS/ADC/Land's End(EGHC).json
+++ b/UK/vATIS/ADC/Land's End(EGHC).json
@@ -121,34 +121,39 @@
                 "transitionLevel": {
                     "values": [
                         {
-                            "low": 1032,
-                            "high": 1049,
-                            "altitude": 65
-                        },
-                        {
-                            "low": 1014,
-                            "high": 1031,
-                            "altitude": 70
-                        },
-                        {
-                            "low": 995,
-                            "high": 1013,
-                            "altitude": 75
-                        },
-                        {
-                            "low": 977,
-                            "high": 994,
-                            "altitude": 80
+                            "low": 940,
+                            "high": 958,
+                            "altitude": 60
                         },
                         {
                             "low": 959,
                             "high": 976,
-                            "altitude": 85
+                            "altitude": 55
                         },
                         {
-                            "low": 940,
-                            "high": 958,
-                            "altitude": 90
+                            "low": 977,
+                            "high": 994,
+                            "altitude": 50
+                        },
+                        {
+                            "low": 995,
+                            "high": 1013,
+                            "altitude": 45
+                        },
+                        {
+                            "low": 1014,
+                            "high": 1031,
+                            "altitude": 40
+                        },
+                        {
+                            "low": 1032,
+                            "high": 1049,
+                            "altitude": 35
+                        },
+                        {
+                            "low": 1050,
+                            "high": 1060,
+                            "altitude": 30
                         }
                     ]
                 },


### PR DESCRIPTION
Fixes #694 

# Summary of changes
Split from #695 due reviewability.

## Fixed
- 940 to 958 is FL60.
- 959 to 976 is FL55.
- 977 to 994 is FL50.
- 995 to 1013 is FL45.
- 1014 to 1031 is FL40.
- 1032 to 1049 is FL35.

## Added
- 1050 - 1060 is FL30.

## Changed
- Consistent low/high/altitude field styling.

All ranges now added aligning with MATS part 1.