### PR TITLE
Fixes #694 - Fixed vATIS transition levels (EGNM)

### DIFF
--- a/UK/vATIS/ADC/Leeds(EGNM).json
+++ b/UK/vATIS/ADC/Leeds(EGNM).json
@@ -129,34 +129,39 @@
         "transitionLevel": {
           "values": [
             {
-              "low": 1032,
-              "high": 1050,
-              "altitude": 55
+              "low": 940,
+              "high": 958,
+              "altitude": 80
             },
             {
-              "low": 1014,
+              "low": 959,
+              "high": 976,
+              "altitude": 75
+            },
+            {
+              "low": 977,
+              "high": 994,
+              "altitude": 70
+            },
+            {
+              "low": 995,
+              "high": 1012,
+              "altitude": 65
+            },
+            {
+              "low": 1013,
               "high": 1031,
               "altitude": 60
             },
             {
-              "low": 996,
-              "high": 1013,
-              "altitude": 65
+              "low": 1032,
+              "high": 1049,
+              "altitude": 55
             },
             {
-              "low": 978,
-              "high": 995,
-              "altitude": 70
-            },
-            {
-              "low": 960,
-              "high": 977,
-              "altitude": 75
-            },
-            {
-              "low": 943,
-              "high": 959,
-              "altitude": 80
+              "low": 1050,
+              "high": 1060,
+              "altitude": 50
             }
           ],
           "template": {

--- a/UK/vATIS/UK - AC North.json
+++ b/UK/vATIS/UK - AC North.json
@@ -68,7 +68,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. AUTOMATIC. DEPARTURE RUNWAY 05L. ARRIVAL RUNWAY 05R [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -111,7 +110,6 @@
           "string": "SRO",
           "spoken": "SINGLE RUNWAY OPERATIONS"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -422,7 +420,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. AUTOMATIC. RUNWAY 07 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -465,7 +462,6 @@
           "string": "SRO",
           "spoken": "SINGLE RUNWAY OPERATIONS"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -776,7 +772,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 09 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -819,7 +814,6 @@
           "string": "SRO",
           "spoken": "SINGLE RUNWAY OPERATIONS"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -1087,7 +1081,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Ronaldsway",
       "Identifier": "EGNS",
@@ -1131,7 +1124,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 08 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -1178,7 +1170,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -1446,7 +1437,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Hawarden",
       "Identifier": "EGNR",
@@ -1490,7 +1480,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 04 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -1537,7 +1526,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -1805,7 +1793,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Warton",
       "Identifier": "EGNO",
@@ -1849,7 +1836,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 07 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -1896,7 +1882,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -2159,7 +2144,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Blackpool",
       "Identifier": "EGNH",
@@ -2203,7 +2187,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 10 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -2250,7 +2233,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -2513,7 +2495,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Norwich",
       "Identifier": "EGSH",
@@ -2557,7 +2538,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 09 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -2604,7 +2584,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -2867,7 +2846,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Leeds Bradford",
       "Identifier": "EGNM",
@@ -2911,7 +2889,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 14 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -2958,7 +2935,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -3181,34 +3157,39 @@
         "transitionLevel": {
           "values": [
             {
-              "Low": 1050,
-              "High": 1060,
-              "Altitude": 50
+              "low": 940,
+              "high": 958,
+              "altitude": 80
             },
             {
-              "Low": 1032,
-              "High": 1049,
-              "Altitude": 55
+              "low": 959,
+              "high": 976,
+              "altitude": 75
             },
             {
-              "Low": 1013,
-              "High": 1031,
-              "Altitude": 60
+              "low": 977,
+              "high": 994,
+              "altitude": 70
             },
             {
-              "Low": 995,
-              "High": 1012,
-              "Altitude": 65
+              "low": 995,
+              "high": 1012,
+              "altitude": 65
             },
             {
-              "Low": 977,
-              "High": 994,
-              "Altitude": 70
+              "low": 1013,
+              "high": 1031,
+              "altitude": 60
             },
             {
-              "Low": 959,
-              "High": 976,
-              "Altitude": 75
+              "low": 1032,
+              "high": 1049,
+              "altitude": 55
+            },
+            {
+              "low": 1050,
+              "high": 1060,
+              "altitude": 50
             }
           ],
           "template": {
@@ -3226,7 +3207,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Humberside",
       "Identifier": "EGNJ",
@@ -3270,7 +3250,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 02 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -3317,7 +3296,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -3585,7 +3563,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Teeside",
       "Identifier": "EGNV",
@@ -3629,7 +3606,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 05 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -3676,7 +3652,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -3944,6 +3919,5 @@
       },
       "NotamsBeforeFreeText": false
     }
-
   ]
 }

--- a/UK/vATIS/UK - PC MAN.json
+++ b/UK/vATIS/UK - PC MAN.json
@@ -92,7 +92,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. AUTOMATIC. DEPARTURE RUNWAY 05L. ARRIVAL RUNWAY 05R [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -135,7 +134,6 @@
           "string": "SRO",
           "spoken": "SINGLE RUNWAY OPERATIONS"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -458,7 +456,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. AUTOMATIC. RUNWAY 07 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -501,7 +498,6 @@
           "string": "SRO",
           "spoken": "SINGLE RUNWAY OPERATIONS"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -836,7 +832,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 09 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -879,7 +874,6 @@
           "string": "SRO",
           "spoken": "SINGLE RUNWAY OPERATIONS"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -1147,7 +1141,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Ronaldsway",
       "Identifier": "EGNS",
@@ -1215,7 +1208,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 08 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -1262,7 +1254,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -1530,7 +1521,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Hawarden",
       "Identifier": "EGNR",
@@ -1598,7 +1588,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 04 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -1645,7 +1634,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -1913,7 +1901,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Warton",
       "Identifier": "EGNO",
@@ -1981,7 +1968,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 07 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -2028,7 +2014,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -2291,7 +2276,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Blackpool",
       "Identifier": "EGNH",
@@ -2359,7 +2343,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 10 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -2406,7 +2389,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -2669,7 +2651,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Leeds Bradford",
       "Identifier": "EGNM",
@@ -2725,7 +2706,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 14 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -2772,7 +2752,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -2995,34 +2974,39 @@
         "transitionLevel": {
           "values": [
             {
-              "Low": 1050,
-              "High": 1060,
-              "Altitude": 50
+              "low": 940,
+              "high": 958,
+              "altitude": 80
             },
             {
-              "Low": 1032,
-              "High": 1049,
-              "Altitude": 55
+              "low": 959,
+              "high": 976,
+              "altitude": 75
             },
             {
-              "Low": 1013,
-              "High": 1031,
-              "Altitude": 60
+              "low": 977,
+              "high": 994,
+              "altitude": 70
             },
             {
-              "Low": 995,
-              "High": 1012,
-              "Altitude": 65
+              "low": 995,
+              "high": 1012,
+              "altitude": 65
             },
             {
-              "Low": 977,
-              "High": 994,
-              "Altitude": 70
+              "low": 1013,
+              "high": 1031,
+              "altitude": 60
             },
             {
-              "Low": 959,
-              "High": 976,
-              "Altitude": 75
+              "low": 1032,
+              "high": 1049,
+              "altitude": 55
+            },
+            {
+              "low": 1050,
+              "high": 1060,
+              "altitude": 50
             }
           ],
           "template": {
@@ -3040,7 +3024,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Humberside",
       "Identifier": "EGNJ",
@@ -3096,7 +3079,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 02 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -3143,7 +3125,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -3411,7 +3392,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Teeside",
       "Identifier": "EGNV",
@@ -3467,7 +3447,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 05 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -3514,7 +3493,6 @@
           "String": "21/03",
           "Spoken": "TWO-ONE-ZERO-THREE"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -3782,6 +3760,5 @@
       },
       "NotamsBeforeFreeText": false
     }
-
   ]
 }


### PR DESCRIPTION
Fixes #694 

# Summary of changes
Split from #695 due reviewability.

## Fixed
- 940 to 958 is FL80.
- 959 to 976 is FL75.
- 977 to 994 is FL70.
- 995 to 1012 is FL65.
- 1013 to 1031 is FL60.
- 1032 to 1049 is FL55.

## Added
- 1050 - 1060 is FL50.

## Changed
- Consistent low/high/altitude field styling.

All ranges now added aligning with MATS part 1.