### PR TITLE
Fixes #694 - Fixed vATIS transition levels (EGMD)

### DIFF
--- a/UK/vATIS/ADC/Lydd(EGMD).json
+++ b/UK/vATIS/ADC/Lydd(EGMD).json
@@ -119,24 +119,9 @@
                 "transitionLevel": {
                     "values": [
                         {
-                            "low": 1032,
-                            "high": 1049,
-                            "altitude": 65
-                        },
-                        {
-                            "low": 1014,
-                            "high": 1031,
-                            "altitude": 70
-                        },
-                        {
-                            "low": 995,
-                            "high": 1013,
-                            "altitude": 75
-                        },
-                        {
-                            "low": 977,
-                            "high": 994,
-                            "altitude": 80
+                            "low": 940,
+                            "high": 958,
+                            "altitude": 90
                         },
                         {
                             "low": 959,
@@ -144,9 +129,29 @@
                             "altitude": 85
                         },
                         {
-                            "low": 940,
-                            "high": 958,
-                            "altitude": 90
+                            "low": 977,
+                            "high": 994,
+                            "altitude": 80
+                        },
+                        {
+                            "low": 995,
+                            "high": 1013,
+                            "altitude": 75
+                        },
+                        {
+                            "low": 1014,
+                            "high": 1031,
+                            "altitude": 70
+                        },
+                        {
+                            "low": 1032,
+                            "high": 1049,
+                            "altitude": 65
+                        },
+                        {
+                            "low": 1050,
+                            "high": 1060,
+                            "altitude": 60
                         }
                     ],
                     "template": {


### PR DESCRIPTION
Fixes #694 

# Summary of changes
Split from #695 due reviewability.

## Fixed
- 940 to 958 is FL90.
- 959 to 976 is FL85.
- 977 to 994 is FL80.
- 995 to 1013 is FL75.
- 1014 to 1031 is FL70.
- 1032 to 1049 is FL65.

## Added
- 1050 - 1060 is FL60.

## Changed
- Consistent low/high/altitude field styling.

All ranges now added aligning with MATS part 1.