### PR TITLE
Fixes #694 - Fixed vATIS transition levels (EGHQ)

### DIFF
--- a/UK/vATIS/ADC/Newquay (EGHQ).json
+++ b/UK/vATIS/ADC/Newquay (EGHQ).json
@@ -112,34 +112,39 @@
                 "transitionLevel": {
                     "values": [
                         {
-                            "low": 1032,
-                            "high": 1049,
-                            "altitude": 65
-                        },
-                        {
-                            "low": 1014,
-                            "high": 1031,
-                            "altitude": 70
-                        },
-                        {
-                            "low": 995,
-                            "high": 1013,
-                            "altitude": 75
-                        },
-                        {
-                            "low": 977,
-                            "high": 994,
-                            "altitude": 80
+                            "low": 940,
+                            "high": 958,
+                            "altitude": 60
                         },
                         {
                             "low": 959,
                             "high": 976,
-                            "altitude": 85
+                            "altitude": 55
                         },
                         {
-                            "low": 940,
-                            "high": 958,
-                            "altitude": 90
+                            "low": 977,
+                            "high": 994,
+                            "altitude": 50
+                        },
+                        {
+                            "low": 995,
+                            "high": 1013,
+                            "altitude": 45
+                        },
+                        {
+                            "low": 1014,
+                            "high": 1031,
+                            "altitude": 40
+                        },
+                        {
+                            "low": 1032,
+                            "high": 1049,
+                            "altitude": 35
+                        },
+                        {
+                            "low": 1050,
+                            "high": 1060,
+                            "altitude": 30
                         }
                     ]
                 },

--- a/UK/vATIS/UK - West.json
+++ b/UK/vATIS/UK - West.json
@@ -44,7 +44,6 @@
           "ArbitraryText": null,
           "Template": "NEWQUAY AIRPORT INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 12 IN USE. [TL]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. [ARPT_COND]. [NOTAMS]."
         }
-
       ],
       "Contractions": [
         {
@@ -91,7 +90,6 @@
           "string": "26L/08R",
           "spoken": "TWO SIX LEFT ZERO EIGHT RIGHT"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -314,34 +312,39 @@
         "transitionLevel": {
           "values": [
             {
-              "Low": 940,
-              "High": 958,
-              "Altitude": 90
+              "low": 940,
+              "high": 958,
+              "altitude": 60
             },
             {
-              "Low": 959,
-              "High": 976,
-              "Altitude": 85
+              "low": 959,
+              "high": 976,
+              "altitude": 55
             },
             {
-              "Low": 977,
-              "High": 994,
-              "Altitude": 80
+              "low": 977,
+              "high": 994,
+              "altitude": 50
             },
             {
-              "Low": 995,
-              "High": 1012,
-              "Altitude": 75
+              "low": 995,
+              "high": 1013,
+              "altitude": 45
             },
             {
-              "Low": 1013,
-              "High": 1031,
-              "Altitude": 70
+              "low": 1014,
+              "high": 1031,
+              "altitude": 40
             },
             {
-              "Low": 1032,
-              "High": 1049,
-              "Altitude": 65
+              "low": 1032,
+              "high": 1049,
+              "altitude": 35
+            },
+            {
+              "low": 1050,
+              "high": 1060,
+              "altitude": 30
             }
           ],
           "template": {
@@ -426,7 +429,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 12 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -473,7 +475,6 @@
           "string": "26L/08R",
           "spoken": "TWO SIX LEFT ZERO EIGHT RIGHT"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -784,7 +785,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 08 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -831,7 +831,6 @@
           "string": "26L/08R",
           "spoken": "TWO SIX LEFT ZERO EIGHT RIGHT"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -1142,7 +1141,6 @@
           "ArbitraryText": null,
           "Template": "JERSEY INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 08 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -1189,7 +1187,6 @@
           "string": "26L/08R",
           "spoken": "TWO SIX LEFT ZERO EIGHT RIGHT"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -1500,7 +1497,6 @@
           "ArbitraryText": null,
           "Template": "GUERNSEY INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 09 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
       ],
       "Contractions": [
         {
@@ -1547,7 +1543,6 @@
           "string": "26L/08R",
           "spoken": "TWO SIX LEFT ZERO EIGHT RIGHT"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -1930,7 +1925,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS GLOSTER INFORMATION [ATIS_CODE] TIME [OBS_TIME]. RUNWAY 04 IN USE. LEFT HAND CIRCUIT. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. [ARPT_COND]. [NOTAMS]. ON FIRST CONTACT READ BACK ALTIMETER SETTING IN USE. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE]"
         }
-
       ],
       "Contractions": [
         {
@@ -1977,7 +1971,6 @@
           "string": "26L/08R",
           "spoken": "TWO SIX LEFT ZERO EIGHT RIGHT"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -2245,7 +2238,6 @@
       },
       "NotamsBeforeFreeText": false
     },
-
     {
       "Name": "Bristol",
       "Identifier": "EGGD",
@@ -2313,8 +2305,6 @@
           "ArbitraryText": null,
           "Template": "THIS IS [FACILITY] INFORMATION [ATIS_CODE] AT TIME [OBS_TIME]. RUNWAY 09 IN USE. [TL]. [NOTAMS]. [ARPT_COND]. [WIND]. [VIS]. [RVR]. [PRESENT_WX]. [CLOUDS]. [TEMP]. [DEW]. [PRESSURE]. ACKNOWLEDGE RECEIPT OF INFORMATION [ATIS_CODE] AND ADVISE AIRCRAFT TYPE ON FIRST CONTACT."
         }
-
-
       ],
       "Contractions": [
         {
@@ -2361,7 +2351,6 @@
           "string": "26L/08R",
           "spoken": "TWO SIX LEFT ZERO EIGHT RIGHT"
         }
-
       ],
       "AirportConditionDefinitions": [],
       "AirportConditionsBeforeFreeText": false,
@@ -2629,10 +2618,5 @@
       },
       "NotamsBeforeFreeText": false
     }
-
-
-
-
-
   ]
 }


### PR DESCRIPTION
Fixes #694 

# Summary of changes
Split from #695 due reviewability.

## Fixed
- 940 to 958 is FL60.
- 959 to 976 is FL55.
- 977 to 994 is FL50.
- 995 to 1013 is FL45.
- 1014 to 1031 is FL40.
- 1032 to 1049 is FL35.

## Added
- 1050 - 1060 is FL30.

## Changed
- Consistent low/high/altitude field styling.

All ranges now added aligning with MATS part 1.