### PR TITLE
Fixes #694 - Fixed vATIS transition levels (Severn)

### DIFF
--- a/UK/vATIS/ADC/Severn(EGFF & EGGD & EGSY).json
+++ b/UK/vATIS/ADC/Severn(EGFF & EGGD & EGSY).json
@@ -114,24 +114,9 @@
         "transitionLevel": {
           "values": [
             {
-              "low": 1032,
-              "high": 1049,
-              "altitude": 65
-            },
-            {
-              "low": 1014,
-              "high": 1031,
-              "altitude": 70
-            },
-            {
-              "low": 995,
-              "high": 1013,
-              "altitude": 75
-            },
-            {
-              "low": 977,
-              "high": 994,
-              "altitude": 80
+              "low": 940,
+              "high": 958,
+              "altitude": 90
             },
             {
               "low": 959,
@@ -139,9 +124,29 @@
               "altitude": 85
             },
             {
-              "low": 940,
-              "high": 958,
-              "altitude": 90
+              "low": 977,
+              "high": 994,
+              "altitude": 80
+            },
+            {
+              "low": 995,
+              "high": 1013,
+              "altitude": 75
+            },
+            {
+              "low": 1014,
+              "high": 1031,
+              "altitude": 70
+            },
+            {
+              "low": 1032,
+              "high": 1049,
+              "altitude": 65
+            },
+            {
+              "low": 1050,
+              "high": 1060,
+              "altitude": 60
             }
           ],
           "template": {
@@ -272,24 +277,9 @@
         "transitionLevel": {
           "values": [
             {
-              "low": 1032,
-              "high": 1049,
-              "altitude": 65
-            },
-            {
-              "low": 1014,
-              "high": 1031,
-              "altitude": 70
-            },
-            {
-              "low": 995,
-              "high": 1013,
-              "altitude": 75
-            },
-            {
-              "low": 977,
-              "high": 994,
-              "altitude": 80
+              "low": 940,
+              "high": 958,
+              "altitude": 90
             },
             {
               "low": 959,
@@ -297,9 +287,29 @@
               "altitude": 85
             },
             {
-              "low": 940,
-              "high": 958,
-              "altitude": 90
+              "low": 977,
+              "high": 994,
+              "altitude": 80
+            },
+            {
+              "low": 995,
+              "high": 1013,
+              "altitude": 75
+            },
+            {
+              "low": 1014,
+              "high": 1031,
+              "altitude": 70
+            },
+            {
+              "low": 1032,
+              "high": 1049,
+              "altitude": 65
+            },
+            {
+              "low": 1050,
+              "high": 1060,
+              "altitude": 60
             }
           ]
         },

--- a/UK/vATIS/UK - LON_CTR Only.json
+++ b/UK/vATIS/UK - LON_CTR Only.json
@@ -4182,34 +4182,39 @@
         "transitionLevel": {
           "values": [
             {
-              "Low": 940,
-              "High": 958,
-              "Altitude": 90
+              "low": 940,
+              "high": 958,
+              "altitude": 90
             },
             {
-              "Low": 959,
-              "High": 976,
-              "Altitude": 85
+              "low": 959,
+              "high": 976,
+              "altitude": 85
             },
             {
-              "Low": 977,
-              "High": 994,
-              "Altitude": 80
+              "low": 977,
+              "high": 994,
+              "altitude": 80
             },
             {
-              "Low": 995,
-              "High": 1012,
-              "Altitude": 75
+              "low": 995,
+              "high": 1013,
+              "altitude": 75
             },
             {
-              "Low": 1013,
-              "High": 1031,
-              "Altitude": 70
+              "low": 1014,
+              "high": 1031,
+              "altitude": 70
             },
             {
-              "Low": 1032,
-              "High": 1049,
-              "Altitude": 65
+              "low": 1032,
+              "high": 1049,
+              "altitude": 65
+            },
+            {
+              "low": 1050,
+              "high": 1060,
+              "altitude": 60
             }
           ],
           "template": {
@@ -4526,34 +4531,39 @@
         "transitionLevel": {
           "values": [
             {
-              "Low": 940,
-              "High": 958,
-              "Altitude": 90
+              "low": 940,
+              "high": 958,
+              "altitude": 90
             },
             {
-              "Low": 959,
-              "High": 976,
-              "Altitude": 85
+              "low": 959,
+              "high": 976,
+              "altitude": 85
             },
             {
-              "Low": 977,
-              "High": 994,
-              "Altitude": 80
+              "low": 977,
+              "high": 994,
+              "altitude": 80
             },
             {
-              "Low": 995,
-              "High": 1012,
-              "Altitude": 75
+              "low": 995,
+              "high": 1013,
+              "altitude": 75
             },
             {
-              "Low": 1013,
-              "High": 1031,
-              "Altitude": 70
+              "low": 1014,
+              "high": 1031,
+              "altitude": 70
             },
             {
-              "Low": 1032,
-              "High": 1049,
-              "Altitude": 65
+              "low": 1032,
+              "high": 1049,
+              "altitude": 65
+            },
+            {
+              "low": 1050,
+              "high": 1060,
+              "altitude": 60
             }
           ],
           "template": {

--- a/UK/vATIS/UK - West.json
+++ b/UK/vATIS/UK - West.json
@@ -697,34 +697,39 @@
         "transitionLevel": {
           "values": [
             {
-              "Low": 940,
-              "High": 958,
-              "Altitude": 90
+              "low": 940,
+              "high": 958,
+              "altitude": 90
             },
             {
-              "Low": 959,
-              "High": 976,
-              "Altitude": 85
+              "low": 959,
+              "high": 976,
+              "altitude": 85
             },
             {
-              "Low": 977,
-              "High": 994,
-              "Altitude": 80
+              "low": 977,
+              "high": 994,
+              "altitude": 80
             },
             {
-              "Low": 995,
-              "High": 1012,
-              "Altitude": 75
+              "low": 995,
+              "high": 1013,
+              "altitude": 75
             },
             {
-              "Low": 1013,
-              "High": 1031,
-              "Altitude": 70
+              "low": 1014,
+              "high": 1031,
+              "altitude": 70
             },
             {
-              "Low": 1032,
-              "High": 1049,
-              "Altitude": 65
+              "low": 1032,
+              "high": 1049,
+              "altitude": 65
+            },
+            {
+              "low": 1050,
+              "high": 1060,
+              "altitude": 60
             }
           ],
           "template": {
@@ -2593,34 +2598,39 @@
         "transitionLevel": {
           "values": [
             {
-              "Low": 940,
-              "High": 958,
-              "Altitude": 90
+              "low": 940,
+              "high": 958,
+              "altitude": 90
             },
             {
-              "Low": 959,
-              "High": 976,
-              "Altitude": 85
+              "low": 959,
+              "high": 976,
+              "altitude": 85
             },
             {
-              "Low": 977,
-              "High": 994,
-              "Altitude": 80
+              "low": 977,
+              "high": 994,
+              "altitude": 80
             },
             {
-              "Low": 995,
-              "High": 1012,
-              "Altitude": 75
+              "low": 995,
+              "high": 1013,
+              "altitude": 75
             },
             {
-              "Low": 1013,
-              "High": 1031,
-              "Altitude": 70
+              "low": 1014,
+              "high": 1031,
+              "altitude": 70
             },
             {
-              "Low": 1032,
-              "High": 1049,
-              "Altitude": 65
+              "low": 1032,
+              "high": 1049,
+              "altitude": 65
+            },
+            {
+              "low": 1050,
+              "high": 1060,
+              "altitude": 60
             }
           ],
           "template": {


### PR DESCRIPTION
Fixes #694 

# Summary of changes
Split from #695 due reviewability.

## Fixed
- 940 to 958 is FL90.
- 959 to 976 is FL85.
- 977 to 994 is FL80.
- 995 to 1013 is FL75.
- 1014 to 1031 is FL70.
- 1032 to 1049 is FL65.

## Added
- 1050 - 1060 is FL60.

## Changed
- Consistent low/high/altitude field styling.

All ranges now added aligning with MATS part 1.