### PR TITLE
Fixes #737 - Display Manchester (EGCC) Q2 & E10 holds

### DIFF
--- a/UK/Data/ASR/AC_BB/BBG1.asr
+++ b/UK/Data/ASR/AC_BB/BBG1.asr
@@ -100,6 +100,7 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -128,6 +129,7 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\101:freetext
@@ -202,7 +204,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
-Free Text:SCT2\12:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -236,7 +238,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -309,6 +310,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -335,11 +337,15 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -365,6 +371,7 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -380,6 +387,7 @@ Free Text:SCT2\18:freetext
 Free Text:SCT2\180:freetext
 Free Text:SCT2\18L:freetext
 Free Text:SCT2\18R:freetext
+Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
@@ -409,6 +417,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -452,6 +461,9 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -486,7 +498,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -515,6 +526,7 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -523,13 +535,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -537,6 +545,9 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -637,6 +648,7 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -646,6 +658,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -733,6 +746,7 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -749,6 +763,7 @@ Free Text:SCT2\307:freetext
 Free Text:SCT2\308:freetext
 Free Text:SCT2\309:freetext
 Free Text:SCT2\309:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
@@ -802,6 +817,7 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
@@ -846,6 +862,7 @@ Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -939,9 +956,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -1013,6 +1032,7 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -1045,6 +1065,8 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1053,17 +1075,13 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1079,6 +1097,9 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1101,6 +1122,8 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1109,7 +1132,9 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
@@ -1134,6 +1159,7 @@ Free Text:SCT2\55R:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\560:freetext
 Free Text:SCT2\561:freetext
 Free Text:SCT2\561:freetext
@@ -1155,6 +1181,7 @@ Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1169,9 +1196,11 @@ Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
@@ -1180,6 +1209,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1221,6 +1251,7 @@ Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\601:freetext
 Free Text:SCT2\602:freetext
 Free Text:SCT2\603:freetext
@@ -1230,6 +1261,8 @@ Free Text:SCT2\606:freetext
 Free Text:SCT2\607:freetext
 Free Text:SCT2\608:freetext
 Free Text:SCT2\609:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
@@ -1245,9 +1278,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1256,17 +1296,24 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1314,10 +1361,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1325,26 +1379,34 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1386,7 +1448,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1441,6 +1505,7 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
@@ -1465,6 +1530,8 @@ Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
+Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1689,6 +1756,7 @@ Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4E:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
@@ -1744,14 +1812,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1835,7 +1905,7 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
-Free Text:SCT2\B2:freetext
+Free Text:SCT2\B1:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1892,6 +1962,8 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1906,6 +1978,8 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
@@ -1914,11 +1988,15 @@ Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -2069,7 +2147,6 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
 Free Text:SCT2\D1:freetext
@@ -2109,7 +2186,9 @@ Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1A:freetext
+Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
@@ -2234,6 +2313,7 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2266,8 +2346,8 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2281,6 +2361,8 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2322,8 +2404,6 @@ Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
-Free Text:SCT2\F1:freetext
-Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
@@ -2341,16 +2421,12 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
@@ -2421,6 +2497,7 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA Apron:freetext
@@ -2432,6 +2509,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2490,12 +2577,14 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2530,6 +2619,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2540,10 +2630,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2569,6 +2669,8 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2606,7 +2708,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2616,9 +2717,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2770,14 +2868,15 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
-Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2789,21 +2888,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2886,6 +2981,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2911,6 +3007,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2950,9 +3047,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2967,6 +3066,7 @@ Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -3013,6 +3113,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -3082,6 +3183,8 @@ Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGAA Belfast Aldergrove:
 Geo:EGAC Belfast City:
 Geo:EGAE City of Derry:

--- a/UK/Data/ASR/AC_BB/BBG2.asr
+++ b/UK/Data/ASR/AC_BB/BBG2.asr
@@ -100,6 +100,7 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -128,6 +129,7 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\101:freetext
@@ -202,7 +204,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
-Free Text:SCT2\12:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -236,7 +238,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -309,6 +310,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -335,11 +337,15 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -365,6 +371,7 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -380,6 +387,7 @@ Free Text:SCT2\18:freetext
 Free Text:SCT2\180:freetext
 Free Text:SCT2\18L:freetext
 Free Text:SCT2\18R:freetext
+Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
@@ -409,6 +417,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -452,6 +461,9 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -486,7 +498,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -515,6 +526,7 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -523,13 +535,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -537,6 +545,9 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -637,6 +648,7 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -646,6 +658,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -733,6 +746,7 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -749,6 +763,7 @@ Free Text:SCT2\307:freetext
 Free Text:SCT2\308:freetext
 Free Text:SCT2\309:freetext
 Free Text:SCT2\309:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
@@ -802,6 +817,7 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
@@ -846,6 +862,7 @@ Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -939,9 +956,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -1013,6 +1032,7 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -1045,6 +1065,8 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1053,17 +1075,13 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1079,6 +1097,9 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1101,6 +1122,8 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1109,7 +1132,9 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
@@ -1134,6 +1159,7 @@ Free Text:SCT2\55R:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\560:freetext
 Free Text:SCT2\561:freetext
 Free Text:SCT2\561:freetext
@@ -1155,6 +1181,7 @@ Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1169,9 +1196,11 @@ Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
@@ -1180,6 +1209,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1221,6 +1251,7 @@ Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\601:freetext
 Free Text:SCT2\602:freetext
 Free Text:SCT2\603:freetext
@@ -1230,6 +1261,8 @@ Free Text:SCT2\606:freetext
 Free Text:SCT2\607:freetext
 Free Text:SCT2\608:freetext
 Free Text:SCT2\609:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
@@ -1245,9 +1278,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1256,17 +1296,24 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1314,10 +1361,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1325,26 +1379,34 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1386,7 +1448,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1441,6 +1505,7 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
@@ -1465,6 +1530,8 @@ Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
+Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1689,6 +1756,7 @@ Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4E:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
@@ -1744,14 +1812,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1835,7 +1905,7 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
-Free Text:SCT2\B2:freetext
+Free Text:SCT2\B1:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1892,6 +1962,8 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1906,6 +1978,8 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
@@ -1914,11 +1988,15 @@ Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -2069,7 +2147,6 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
 Free Text:SCT2\D1:freetext
@@ -2109,7 +2186,9 @@ Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1A:freetext
+Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
@@ -2234,6 +2313,7 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2266,8 +2346,8 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2281,6 +2361,8 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2322,8 +2404,6 @@ Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
-Free Text:SCT2\F1:freetext
-Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
@@ -2341,16 +2421,12 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
@@ -2421,6 +2497,7 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA Apron:freetext
@@ -2432,6 +2509,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2490,12 +2577,14 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2530,6 +2619,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2540,10 +2630,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2569,6 +2669,8 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2606,7 +2708,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2616,9 +2717,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2770,14 +2868,15 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
-Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2789,21 +2888,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2886,6 +2981,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2911,6 +3007,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2950,9 +3047,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2967,6 +3066,7 @@ Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -3013,6 +3113,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -3082,6 +3183,8 @@ Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGAA Belfast Aldergrove:
 Geo:EGAC Belfast City:
 Geo:EGAE City of Derry:

--- a/UK/Data/ASR/AC_BB/BBG3.asr
+++ b/UK/Data/ASR/AC_BB/BBG3.asr
@@ -100,6 +100,7 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -128,6 +129,7 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\101:freetext
@@ -202,7 +204,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
-Free Text:SCT2\12:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -236,7 +238,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -309,6 +310,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -335,11 +337,15 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -365,6 +371,7 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -380,6 +387,7 @@ Free Text:SCT2\18:freetext
 Free Text:SCT2\180:freetext
 Free Text:SCT2\18L:freetext
 Free Text:SCT2\18R:freetext
+Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
@@ -409,6 +417,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -452,6 +461,9 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -486,7 +498,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -515,6 +526,7 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -523,13 +535,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -537,6 +545,9 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -637,6 +648,7 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -646,6 +658,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -733,6 +746,7 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -749,6 +763,7 @@ Free Text:SCT2\307:freetext
 Free Text:SCT2\308:freetext
 Free Text:SCT2\309:freetext
 Free Text:SCT2\309:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
@@ -802,6 +817,7 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
@@ -846,6 +862,7 @@ Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -939,9 +956,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -1013,6 +1032,7 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -1045,6 +1065,8 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1053,17 +1075,13 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1079,6 +1097,9 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1101,6 +1122,8 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1109,7 +1132,9 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
@@ -1134,6 +1159,7 @@ Free Text:SCT2\55R:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\560:freetext
 Free Text:SCT2\561:freetext
 Free Text:SCT2\561:freetext
@@ -1155,6 +1181,7 @@ Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1169,9 +1196,11 @@ Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
@@ -1180,6 +1209,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1221,6 +1251,7 @@ Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\601:freetext
 Free Text:SCT2\602:freetext
 Free Text:SCT2\603:freetext
@@ -1230,6 +1261,8 @@ Free Text:SCT2\606:freetext
 Free Text:SCT2\607:freetext
 Free Text:SCT2\608:freetext
 Free Text:SCT2\609:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
@@ -1245,9 +1278,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1256,17 +1296,24 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1314,10 +1361,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1325,26 +1379,34 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1386,7 +1448,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1441,6 +1505,7 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
@@ -1465,6 +1530,8 @@ Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
+Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1689,6 +1756,7 @@ Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4E:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
@@ -1744,14 +1812,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1835,7 +1905,7 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
-Free Text:SCT2\B2:freetext
+Free Text:SCT2\B1:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1892,6 +1962,8 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1906,6 +1978,8 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
@@ -1914,11 +1988,15 @@ Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -2069,7 +2147,6 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
 Free Text:SCT2\D1:freetext
@@ -2109,7 +2186,9 @@ Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1A:freetext
+Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
@@ -2234,6 +2313,7 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2266,8 +2346,8 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2281,6 +2361,8 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2322,8 +2404,6 @@ Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
-Free Text:SCT2\F1:freetext
-Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
@@ -2341,16 +2421,12 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
@@ -2421,6 +2497,7 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA Apron:freetext
@@ -2432,6 +2509,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2490,12 +2577,14 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2530,6 +2619,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2540,10 +2630,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2569,6 +2669,8 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2606,7 +2708,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2616,9 +2717,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2770,14 +2868,15 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
-Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2789,21 +2888,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2886,6 +2981,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2911,6 +3007,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2950,9 +3047,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2967,6 +3066,7 @@ Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -3013,6 +3113,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -3082,6 +3183,8 @@ Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGAA Belfast Aldergrove:
 Geo:EGAC Belfast City:
 Geo:EGAE City of Derry:

--- a/UK/Data/ASR/AC_BB/BBG4.asr
+++ b/UK/Data/ASR/AC_BB/BBG4.asr
@@ -100,6 +100,7 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -128,6 +129,7 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\101:freetext
@@ -202,7 +204,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
-Free Text:SCT2\12:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -236,7 +238,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -309,6 +310,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -335,11 +337,15 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -365,6 +371,7 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -380,6 +387,7 @@ Free Text:SCT2\18:freetext
 Free Text:SCT2\180:freetext
 Free Text:SCT2\18L:freetext
 Free Text:SCT2\18R:freetext
+Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
@@ -409,6 +417,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -452,6 +461,9 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -486,7 +498,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -515,6 +526,7 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -523,13 +535,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -537,6 +545,9 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -637,6 +648,7 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -646,6 +658,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -733,6 +746,7 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -749,6 +763,7 @@ Free Text:SCT2\307:freetext
 Free Text:SCT2\308:freetext
 Free Text:SCT2\309:freetext
 Free Text:SCT2\309:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
@@ -802,6 +817,7 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
@@ -846,6 +862,7 @@ Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -939,9 +956,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -1013,6 +1032,7 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -1045,6 +1065,8 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1053,17 +1075,13 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1079,6 +1097,9 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1101,6 +1122,8 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1109,7 +1132,9 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
@@ -1134,6 +1159,7 @@ Free Text:SCT2\55R:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\560:freetext
 Free Text:SCT2\561:freetext
 Free Text:SCT2\561:freetext
@@ -1155,6 +1181,7 @@ Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1169,9 +1196,11 @@ Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
@@ -1180,6 +1209,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1221,6 +1251,7 @@ Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\601:freetext
 Free Text:SCT2\602:freetext
 Free Text:SCT2\603:freetext
@@ -1230,6 +1261,8 @@ Free Text:SCT2\606:freetext
 Free Text:SCT2\607:freetext
 Free Text:SCT2\608:freetext
 Free Text:SCT2\609:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
@@ -1245,9 +1278,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1256,17 +1296,24 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1314,10 +1361,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1325,26 +1379,34 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1386,7 +1448,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1441,6 +1505,7 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
@@ -1465,6 +1530,8 @@ Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
+Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1689,6 +1756,7 @@ Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4E:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
@@ -1744,14 +1812,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1835,7 +1905,7 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
-Free Text:SCT2\B2:freetext
+Free Text:SCT2\B1:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1892,6 +1962,8 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1906,6 +1978,8 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
@@ -1914,11 +1988,15 @@ Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -2069,7 +2147,6 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
 Free Text:SCT2\D1:freetext
@@ -2109,7 +2186,9 @@ Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1A:freetext
+Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
@@ -2234,6 +2313,7 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2266,8 +2346,8 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2281,6 +2361,8 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2322,8 +2404,6 @@ Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
-Free Text:SCT2\F1:freetext
-Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
@@ -2341,16 +2421,12 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
@@ -2421,6 +2497,7 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA Apron:freetext
@@ -2432,6 +2509,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2490,12 +2577,14 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2530,6 +2619,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2540,10 +2630,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2569,6 +2669,8 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2606,7 +2708,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2616,9 +2717,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2770,14 +2868,15 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
-Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2789,21 +2888,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2886,6 +2981,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2911,6 +3007,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2950,9 +3047,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2967,6 +3066,7 @@ Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -3013,6 +3113,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -3082,6 +3183,8 @@ Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGAA Belfast Aldergrove:
 Geo:EGAC Belfast City:
 Geo:EGAE City of Derry:

--- a/UK/Data/ASR/AC_BB/BBG5.asr
+++ b/UK/Data/ASR/AC_BB/BBG5.asr
@@ -101,6 +101,7 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -129,6 +130,7 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\101:freetext
@@ -203,7 +205,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
-Free Text:SCT2\12:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -237,7 +239,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -310,6 +311,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -336,11 +338,15 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -366,6 +372,7 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -381,6 +388,7 @@ Free Text:SCT2\18:freetext
 Free Text:SCT2\180:freetext
 Free Text:SCT2\18L:freetext
 Free Text:SCT2\18R:freetext
+Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
@@ -410,6 +418,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -453,6 +462,9 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -487,7 +499,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -516,6 +527,7 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -524,13 +536,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -538,6 +546,9 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -638,6 +649,7 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -647,6 +659,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -734,6 +747,7 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -750,6 +764,7 @@ Free Text:SCT2\307:freetext
 Free Text:SCT2\308:freetext
 Free Text:SCT2\309:freetext
 Free Text:SCT2\309:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
@@ -803,6 +818,7 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
@@ -847,6 +863,7 @@ Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -940,9 +957,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -1014,6 +1033,7 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -1046,6 +1066,8 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1054,17 +1076,13 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1080,6 +1098,9 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1102,6 +1123,8 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1110,7 +1133,9 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
@@ -1135,6 +1160,7 @@ Free Text:SCT2\55R:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\560:freetext
 Free Text:SCT2\561:freetext
 Free Text:SCT2\561:freetext
@@ -1156,6 +1182,7 @@ Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1170,9 +1197,11 @@ Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
@@ -1181,6 +1210,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1222,6 +1252,7 @@ Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\601:freetext
 Free Text:SCT2\602:freetext
 Free Text:SCT2\603:freetext
@@ -1231,6 +1262,8 @@ Free Text:SCT2\606:freetext
 Free Text:SCT2\607:freetext
 Free Text:SCT2\608:freetext
 Free Text:SCT2\609:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
@@ -1246,9 +1279,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1257,17 +1297,24 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1315,10 +1362,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1326,26 +1380,34 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1387,7 +1449,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1442,6 +1506,7 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
@@ -1466,6 +1531,8 @@ Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
+Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1690,6 +1757,7 @@ Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4E:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
@@ -1745,14 +1813,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1836,7 +1906,7 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
-Free Text:SCT2\B2:freetext
+Free Text:SCT2\B1:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1893,6 +1963,8 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1907,6 +1979,8 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
@@ -1915,11 +1989,15 @@ Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -2070,7 +2148,6 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
 Free Text:SCT2\D1:freetext
@@ -2110,7 +2187,9 @@ Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1A:freetext
+Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
@@ -2235,6 +2314,7 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2267,8 +2347,8 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2282,6 +2362,8 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2323,8 +2405,6 @@ Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
-Free Text:SCT2\F1:freetext
-Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
@@ -2342,16 +2422,12 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
@@ -2422,6 +2498,7 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA Apron:freetext
@@ -2433,6 +2510,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2491,12 +2578,14 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2531,6 +2620,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2541,10 +2631,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2570,6 +2670,8 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2607,7 +2709,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2617,9 +2718,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2771,14 +2869,15 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
-Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2790,21 +2889,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2887,6 +2982,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2912,6 +3008,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2951,9 +3048,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2968,6 +3067,7 @@ Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -3014,6 +3114,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -3083,6 +3184,8 @@ Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGAA Belfast Aldergrove:
 Geo:EGAC Belfast City:
 Geo:EGAE City of Derry:

--- a/UK/Data/ASR/AC_BB/BBG6.asr
+++ b/UK/Data/ASR/AC_BB/BBG6.asr
@@ -100,6 +100,7 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -128,6 +129,7 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\101:freetext
@@ -202,7 +204,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
-Free Text:SCT2\12:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -236,7 +238,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -309,6 +310,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -335,11 +337,15 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -365,6 +371,7 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -380,6 +387,7 @@ Free Text:SCT2\18:freetext
 Free Text:SCT2\180:freetext
 Free Text:SCT2\18L:freetext
 Free Text:SCT2\18R:freetext
+Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
@@ -409,6 +417,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -452,6 +461,9 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -486,7 +498,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -515,6 +526,7 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -523,13 +535,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -537,6 +545,9 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -637,6 +648,7 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -646,6 +658,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -733,6 +746,7 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -749,6 +763,7 @@ Free Text:SCT2\307:freetext
 Free Text:SCT2\308:freetext
 Free Text:SCT2\309:freetext
 Free Text:SCT2\309:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
@@ -802,6 +817,7 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
@@ -846,6 +862,7 @@ Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -939,9 +956,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -1013,6 +1032,7 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -1045,6 +1065,8 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1053,17 +1075,13 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1079,6 +1097,9 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1101,6 +1122,8 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1109,7 +1132,9 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
@@ -1134,6 +1159,7 @@ Free Text:SCT2\55R:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\560:freetext
 Free Text:SCT2\561:freetext
 Free Text:SCT2\561:freetext
@@ -1155,6 +1181,7 @@ Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1169,9 +1196,11 @@ Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
@@ -1180,6 +1209,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1221,6 +1251,7 @@ Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\601:freetext
 Free Text:SCT2\602:freetext
 Free Text:SCT2\603:freetext
@@ -1230,6 +1261,8 @@ Free Text:SCT2\606:freetext
 Free Text:SCT2\607:freetext
 Free Text:SCT2\608:freetext
 Free Text:SCT2\609:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
@@ -1245,9 +1278,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1256,17 +1296,24 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1314,10 +1361,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1325,26 +1379,34 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1386,7 +1448,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1441,6 +1505,7 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
@@ -1465,6 +1530,8 @@ Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
+Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1689,6 +1756,7 @@ Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4E:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
@@ -1744,14 +1812,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1835,7 +1905,7 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
-Free Text:SCT2\B2:freetext
+Free Text:SCT2\B1:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1892,6 +1962,8 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1906,6 +1978,8 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
@@ -1914,11 +1988,15 @@ Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -2069,7 +2147,6 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
 Free Text:SCT2\D1:freetext
@@ -2109,7 +2186,9 @@ Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1A:freetext
+Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
@@ -2234,6 +2313,7 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2266,8 +2346,8 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2281,6 +2361,8 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2322,8 +2404,6 @@ Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
-Free Text:SCT2\F1:freetext
-Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
@@ -2341,16 +2421,12 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
@@ -2421,6 +2497,7 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA Apron:freetext
@@ -2432,6 +2509,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2490,12 +2577,14 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2530,6 +2619,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2540,10 +2630,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2569,6 +2669,8 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2606,7 +2708,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2616,9 +2717,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2770,14 +2868,15 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
-Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2789,21 +2888,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2886,6 +2981,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2911,6 +3007,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2950,9 +3047,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2967,6 +3066,7 @@ Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -3013,6 +3113,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -3082,6 +3183,8 @@ Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGAA Belfast Aldergrove:
 Geo:EGAC Belfast City:
 Geo:EGAE City of Derry:

--- a/UK/Data/ASR/AC_BB/BBG7.asr
+++ b/UK/Data/ASR/AC_BB/BBG7.asr
@@ -100,6 +100,7 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -128,6 +129,7 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\101:freetext
@@ -202,7 +204,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
-Free Text:SCT2\12:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -236,7 +238,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -309,6 +310,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -335,11 +337,15 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -365,6 +371,7 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -380,6 +387,7 @@ Free Text:SCT2\18:freetext
 Free Text:SCT2\180:freetext
 Free Text:SCT2\18L:freetext
 Free Text:SCT2\18R:freetext
+Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
@@ -409,6 +417,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -452,6 +461,9 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -486,7 +498,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -515,6 +526,7 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -523,13 +535,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -537,6 +545,9 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -637,6 +648,7 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -646,6 +658,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -733,6 +746,7 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -749,6 +763,7 @@ Free Text:SCT2\307:freetext
 Free Text:SCT2\308:freetext
 Free Text:SCT2\309:freetext
 Free Text:SCT2\309:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
@@ -802,6 +817,7 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
@@ -846,6 +862,7 @@ Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -939,9 +956,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -1013,6 +1032,7 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -1045,6 +1065,8 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1053,17 +1075,13 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1079,6 +1097,9 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1101,6 +1122,8 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1109,7 +1132,9 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
@@ -1134,6 +1159,7 @@ Free Text:SCT2\55R:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\560:freetext
 Free Text:SCT2\561:freetext
 Free Text:SCT2\561:freetext
@@ -1155,6 +1181,7 @@ Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1169,9 +1196,11 @@ Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
@@ -1180,6 +1209,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1221,6 +1251,7 @@ Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\601:freetext
 Free Text:SCT2\602:freetext
 Free Text:SCT2\603:freetext
@@ -1230,6 +1261,8 @@ Free Text:SCT2\606:freetext
 Free Text:SCT2\607:freetext
 Free Text:SCT2\608:freetext
 Free Text:SCT2\609:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
@@ -1245,9 +1278,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1256,17 +1296,24 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1314,10 +1361,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1325,26 +1379,34 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1386,7 +1448,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1441,6 +1505,7 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
@@ -1465,6 +1530,8 @@ Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
+Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1689,6 +1756,7 @@ Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4E:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
@@ -1744,14 +1812,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1835,7 +1905,7 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
-Free Text:SCT2\B2:freetext
+Free Text:SCT2\B1:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1892,6 +1962,8 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1906,6 +1978,8 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
@@ -1914,11 +1988,15 @@ Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -2069,7 +2147,6 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
 Free Text:SCT2\D1:freetext
@@ -2109,7 +2186,9 @@ Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1A:freetext
+Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
@@ -2234,6 +2313,7 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2266,8 +2346,8 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2281,6 +2361,8 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2322,8 +2404,6 @@ Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
-Free Text:SCT2\F1:freetext
-Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
@@ -2341,16 +2421,12 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
@@ -2421,6 +2497,7 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA Apron:freetext
@@ -2432,6 +2509,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2490,12 +2577,14 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2530,6 +2619,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2540,10 +2630,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2569,6 +2669,8 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2606,7 +2708,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2616,9 +2717,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2770,14 +2868,15 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
-Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2789,21 +2888,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2886,6 +2981,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2911,6 +3007,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2950,9 +3047,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2967,6 +3066,7 @@ Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -3013,6 +3113,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -3082,6 +3183,8 @@ Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGAA Belfast Aldergrove:
 Geo:EGAC Belfast City:
 Geo:EGAE City of Derry:

--- a/UK/Data/ASR/AC_BB/BBG8.asr
+++ b/UK/Data/ASR/AC_BB/BBG8.asr
@@ -100,6 +100,7 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -128,6 +129,7 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\101:freetext
@@ -202,7 +204,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
-Free Text:SCT2\12:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -236,7 +238,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -309,6 +310,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -335,11 +337,15 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -365,6 +371,7 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -380,6 +387,7 @@ Free Text:SCT2\18:freetext
 Free Text:SCT2\180:freetext
 Free Text:SCT2\18L:freetext
 Free Text:SCT2\18R:freetext
+Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
@@ -409,6 +417,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -452,6 +461,9 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -486,7 +498,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -515,6 +526,7 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -523,13 +535,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -537,6 +545,9 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -637,6 +648,7 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -646,6 +658,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -733,6 +746,7 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -749,6 +763,7 @@ Free Text:SCT2\307:freetext
 Free Text:SCT2\308:freetext
 Free Text:SCT2\309:freetext
 Free Text:SCT2\309:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
@@ -802,6 +817,7 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
@@ -846,6 +862,7 @@ Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -939,9 +956,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -1013,6 +1032,7 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -1045,6 +1065,8 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1053,17 +1075,13 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1079,6 +1097,9 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1101,6 +1122,8 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1109,7 +1132,9 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
@@ -1134,6 +1159,7 @@ Free Text:SCT2\55R:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\560:freetext
 Free Text:SCT2\561:freetext
 Free Text:SCT2\561:freetext
@@ -1155,6 +1181,7 @@ Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1169,9 +1196,11 @@ Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
@@ -1180,6 +1209,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1221,6 +1251,7 @@ Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\601:freetext
 Free Text:SCT2\602:freetext
 Free Text:SCT2\603:freetext
@@ -1230,6 +1261,8 @@ Free Text:SCT2\606:freetext
 Free Text:SCT2\607:freetext
 Free Text:SCT2\608:freetext
 Free Text:SCT2\609:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
@@ -1245,9 +1278,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1256,17 +1296,24 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1314,10 +1361,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1325,26 +1379,34 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1386,7 +1448,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1441,6 +1505,7 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
@@ -1465,6 +1530,8 @@ Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
+Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1689,6 +1756,7 @@ Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4E:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
@@ -1744,14 +1812,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1835,7 +1905,7 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
-Free Text:SCT2\B2:freetext
+Free Text:SCT2\B1:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1892,6 +1962,8 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1906,6 +1978,8 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
@@ -1914,11 +1988,15 @@ Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -2069,7 +2147,6 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
 Free Text:SCT2\D1:freetext
@@ -2109,7 +2186,9 @@ Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1A:freetext
+Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
@@ -2234,6 +2313,7 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2266,8 +2346,8 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2281,6 +2361,8 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2322,8 +2404,6 @@ Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
-Free Text:SCT2\F1:freetext
-Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
@@ -2341,16 +2421,12 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
@@ -2421,6 +2497,7 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA Apron:freetext
@@ -2432,6 +2509,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2490,12 +2577,14 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2530,6 +2619,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2540,10 +2630,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2569,6 +2669,8 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2606,7 +2708,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2616,9 +2717,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2770,14 +2868,15 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
-Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2789,21 +2888,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2886,6 +2981,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2911,6 +3007,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2950,9 +3047,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2967,6 +3066,7 @@ Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -3013,6 +3113,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -3082,6 +3183,8 @@ Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGAA Belfast Aldergrove:
 Geo:EGAC Belfast City:
 Geo:EGAE City of Derry:

--- a/UK/Data/ASR/AC_BB/BBG9.asr
+++ b/UK/Data/ASR/AC_BB/BBG9.asr
@@ -100,6 +100,7 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -128,6 +129,7 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\101:freetext
@@ -202,7 +204,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
-Free Text:SCT2\12:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -236,7 +238,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -309,6 +310,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -335,11 +337,15 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -365,6 +371,7 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -380,6 +387,7 @@ Free Text:SCT2\18:freetext
 Free Text:SCT2\180:freetext
 Free Text:SCT2\18L:freetext
 Free Text:SCT2\18R:freetext
+Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
 Free Text:SCT2\19:freetext
@@ -409,6 +417,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -452,6 +461,9 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -486,7 +498,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -515,6 +526,7 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -523,13 +535,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -537,6 +545,9 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -637,6 +648,7 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -646,6 +658,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -733,6 +746,7 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -749,6 +763,7 @@ Free Text:SCT2\307:freetext
 Free Text:SCT2\308:freetext
 Free Text:SCT2\309:freetext
 Free Text:SCT2\309:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
@@ -802,6 +817,7 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
@@ -846,6 +862,7 @@ Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -939,9 +956,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -1013,6 +1032,7 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -1045,6 +1065,8 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1053,17 +1075,13 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1079,6 +1097,9 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1101,6 +1122,8 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1109,7 +1132,9 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
@@ -1134,6 +1159,7 @@ Free Text:SCT2\55R:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\560:freetext
 Free Text:SCT2\561:freetext
 Free Text:SCT2\561:freetext
@@ -1155,6 +1181,7 @@ Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1169,9 +1196,11 @@ Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
@@ -1180,6 +1209,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1221,6 +1251,7 @@ Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\601:freetext
 Free Text:SCT2\602:freetext
 Free Text:SCT2\603:freetext
@@ -1230,6 +1261,8 @@ Free Text:SCT2\606:freetext
 Free Text:SCT2\607:freetext
 Free Text:SCT2\608:freetext
 Free Text:SCT2\609:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
@@ -1245,9 +1278,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1256,17 +1296,24 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1314,10 +1361,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1325,26 +1379,34 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1386,7 +1448,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1441,6 +1505,7 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
@@ -1465,6 +1530,8 @@ Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
+Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1689,6 +1756,7 @@ Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4E:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
@@ -1744,14 +1812,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1835,7 +1905,7 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
-Free Text:SCT2\B2:freetext
+Free Text:SCT2\B1:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1892,6 +1962,8 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1906,6 +1978,8 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
@@ -1914,11 +1988,15 @@ Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -2069,7 +2147,6 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
 Free Text:SCT2\D1:freetext
@@ -2109,7 +2186,9 @@ Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1A:freetext
+Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
@@ -2234,6 +2313,7 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2266,8 +2346,8 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2281,6 +2361,8 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2322,8 +2404,6 @@ Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
 Free Text:SCT2\F1:freetext
-Free Text:SCT2\F1:freetext
-Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
 Free Text:SCT2\F2:freetext
@@ -2341,16 +2421,12 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
@@ -2421,6 +2497,7 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA:freetext
 Free Text:SCT2\GA Apron:freetext
@@ -2432,6 +2509,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2490,12 +2577,14 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2530,6 +2619,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2540,10 +2630,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2569,6 +2669,8 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2606,7 +2708,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2616,9 +2717,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2770,14 +2868,15 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
-Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2789,21 +2888,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2886,6 +2981,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2911,6 +3007,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2950,9 +3047,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2967,6 +3066,7 @@ Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -3013,6 +3113,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -3082,6 +3183,8 @@ Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGAA Belfast Aldergrove:
 Geo:EGAC Belfast City:
 Geo:EGAE City of Derry:

--- a/UK/Data/ASR/AC_N/Manchester SMR.asr
+++ b/UK/Data/ASR/AC_N/Manchester SMR.asr
@@ -53,7 +53,6 @@ Free Text:SCT2\ R :freetext
 Free Text:SCT2\ R :freetext
 Free Text:SCT2\ R :freetext
 Free Text:SCT2\ R :freetext
-Free Text:SCT2\03D:freetext
 Free Text:SCT2\06L:freetext
 Free Text:SCT2\06R:freetext
 Free Text:SCT2\07:freetext
@@ -96,6 +95,12 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -123,10 +128,10 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
-Free Text:SCT2\100:freetext
-Free Text:SCT2\101:freetext
 Free Text:SCT2\101:freetext
 Free Text:SCT2\101:freetext
 Free Text:SCT2\101:freetext
@@ -186,6 +191,7 @@ Free Text:SCT2\11:freetext
 Free Text:SCT2\11:freetext
 Free Text:SCT2\11:freetext
 Free Text:SCT2\11:freetext
+Free Text:SCT2\11:freetext
 Free Text:SCT2\110:freetext
 Free Text:SCT2\110:freetext
 Free Text:SCT2\111:freetext
@@ -198,6 +204,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -231,7 +238,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -304,6 +310,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -329,11 +336,16 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -359,6 +371,8 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
+Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -403,6 +417,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -440,6 +455,16 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -473,7 +498,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -501,6 +525,8 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -509,13 +535,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -523,6 +545,10 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -547,6 +573,7 @@ Free Text:SCT2\223:freetext
 Free Text:SCT2\224:freetext
 Free Text:SCT2\225:freetext
 Free Text:SCT2\226:freetext
+Free Text:SCT2\23:freetext
 Free Text:SCT2\23:freetext
 Free Text:SCT2\23:freetext
 Free Text:SCT2\23:freetext
@@ -594,6 +621,8 @@ Free Text:SCT2\24:freetext
 Free Text:SCT2\24:freetext
 Free Text:SCT2\24:freetext
 Free Text:SCT2\24:freetext
+Free Text:SCT2\24:freetext
+Free Text:SCT2\24:freetext
 Free Text:SCT2\241:freetext
 Free Text:SCT2\241:freetext
 Free Text:SCT2\242:freetext
@@ -618,6 +647,8 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -627,6 +658,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -636,7 +668,9 @@ Free Text:SCT2\26:freetext
 Free Text:SCT2\26:freetext
 Free Text:SCT2\26:freetext
 Free Text:SCT2\26:freetext
+Free Text:SCT2\26:freetext
 Free Text:SCT2\26S:freetext
+Free Text:SCT2\27:freetext
 Free Text:SCT2\27:freetext
 Free Text:SCT2\27:freetext
 Free Text:SCT2\27:freetext
@@ -653,13 +687,15 @@ Free Text:SCT2\28:freetext
 Free Text:SCT2\28:freetext
 Free Text:SCT2\28:freetext
 Free Text:SCT2\28:freetext
+Free Text:SCT2\28:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
-Free Text:SCT2\29A:freetext
+Free Text:SCT2\29:freetext
+Free Text:SCT2\2A:freetext
 Free Text:SCT2\2A:freetext
 Free Text:SCT2\2A:freetext
 Free Text:SCT2\2B:freetext
@@ -705,6 +741,13 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -729,6 +772,8 @@ Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
+Free Text:SCT2\31:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\310:freetext
 Free Text:SCT2\311:freetext
 Free Text:SCT2\311:freetext
@@ -744,7 +789,7 @@ Free Text:SCT2\317:freetext
 Free Text:SCT2\317A:freetext
 Free Text:SCT2\318:freetext
 Free Text:SCT2\319:freetext
-Free Text:SCT2\31R:freetext
+Free Text:SCT2\32:freetext
 Free Text:SCT2\32:freetext
 Free Text:SCT2\32:freetext
 Free Text:SCT2\32:freetext
@@ -771,13 +816,15 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
 Free Text:SCT2\334:freetext
 Free Text:SCT2\335:freetext
 Free Text:SCT2\336:freetext
-Free Text:SCT2\33L:freetext
+Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
@@ -785,6 +832,7 @@ Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
 Free Text:SCT2\340:freetext
 Free Text:SCT2\342:freetext
+Free Text:SCT2\35:freetext
 Free Text:SCT2\35:freetext
 Free Text:SCT2\35:freetext
 Free Text:SCT2\35:freetext
@@ -797,6 +845,7 @@ Free Text:SCT2\36:freetext
 Free Text:SCT2\36:freetext
 Free Text:SCT2\36:freetext
 Free Text:SCT2\36:freetext
+Free Text:SCT2\36:freetext
 Free Text:SCT2\363:freetext
 Free Text:SCT2\364:freetext
 Free Text:SCT2\365:freetext
@@ -804,12 +853,16 @@ Free Text:SCT2\37:freetext
 Free Text:SCT2\37:freetext
 Free Text:SCT2\37:freetext
 Free Text:SCT2\37:freetext
+Free Text:SCT2\37:freetext
+Free Text:SCT2\38:freetext
 Free Text:SCT2\38:freetext
 Free Text:SCT2\38:freetext
 Free Text:SCT2\38:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -845,6 +898,12 @@ Free Text:SCT2\4:freetext
 Free Text:SCT2\4:freetext
 Free Text:SCT2\4:freetext
 Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\40:freetext
 Free Text:SCT2\40:freetext
 Free Text:SCT2\40:freetext
 Free Text:SCT2\40:freetext
@@ -859,6 +918,7 @@ Free Text:SCT2\406:freetext
 Free Text:SCT2\407:freetext
 Free Text:SCT2\408:freetext
 Free Text:SCT2\409:freetext
+Free Text:SCT2\41:freetext
 Free Text:SCT2\41:freetext
 Free Text:SCT2\41:freetext
 Free Text:SCT2\41:freetext
@@ -896,9 +956,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -933,7 +995,6 @@ Free Text:SCT2\49:freetext
 Free Text:SCT2\49:freetext
 Free Text:SCT2\49:freetext
 Free Text:SCT2\4A:freetext
-Free Text:SCT2\4F:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
@@ -967,6 +1028,12 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -997,6 +1064,9 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1005,17 +1075,14 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1030,6 +1097,10 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1050,6 +1121,9 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1058,10 +1132,12 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
-Free Text:SCT2\551:freetext
+Free Text:SCT2\55:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\551:freetext
 Free Text:SCT2\552:freetext
 Free Text:SCT2\552:freetext
@@ -1080,6 +1156,7 @@ Free Text:SCT2\559:freetext
 Free Text:SCT2\55C:freetext
 Free Text:SCT2\55L:freetext
 Free Text:SCT2\55R:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
@@ -1103,6 +1180,8 @@ Free Text:SCT2\568:freetext
 Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1116,9 +1195,13 @@ Free Text:SCT2\57C:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
 Free Text:SCT2\591:freetext
@@ -1126,6 +1209,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1159,6 +1243,12 @@ Free Text:SCT2\6:freetext
 Free Text:SCT2\6:freetext
 Free Text:SCT2\6:freetext
 Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
@@ -1176,6 +1266,8 @@ Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\611:freetext
 Free Text:SCT2\612:freetext
 Free Text:SCT2\613:freetext
@@ -1186,9 +1278,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1197,17 +1296,26 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
+Free Text:SCT2\7:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1253,10 +1361,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1264,26 +1379,36 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
+Free Text:SCT2\8:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1323,7 +1448,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1376,6 +1503,10 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
+Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
 Free Text:SCT2\903:freetext
@@ -1383,19 +1514,23 @@ Free Text:SCT2\905:freetext
 Free Text:SCT2\907:freetext
 Free Text:SCT2\909:freetext
 Free Text:SCT2\91:freetext
+Free Text:SCT2\91:freetext
 Free Text:SCT2\911:freetext
 Free Text:SCT2\913:freetext
 Free Text:SCT2\915:freetext
 Free Text:SCT2\917:freetext
 Free Text:SCT2\919:freetext
 Free Text:SCT2\92:freetext
+Free Text:SCT2\92:freetext
 Free Text:SCT2\925:freetext
 Free Text:SCT2\927:freetext
 Free Text:SCT2\929:freetext
 Free Text:SCT2\93:freetext
+Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1423,6 +1558,12 @@ Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
+Free Text:SCT2\A:freetext
+Free Text:SCT2\A:freetext
+Free Text:SCT2\A:freetext
+Free Text:SCT2\A1:freetext
+Free Text:SCT2\A1:freetext
+Free Text:SCT2\A1:freetext
 Free Text:SCT2\A1:freetext
 Free Text:SCT2\A1:freetext
 Free Text:SCT2\A1:freetext
@@ -1538,6 +1679,9 @@ Free Text:SCT2\A2:freetext
 Free Text:SCT2\A2:freetext
 Free Text:SCT2\A2:freetext
 Free Text:SCT2\A2:freetext
+Free Text:SCT2\A2:freetext
+Free Text:SCT2\A2:freetext
+Free Text:SCT2\A2:freetext
 Free Text:SCT2\A20:freetext
 Free Text:SCT2\A24:freetext
 Free Text:SCT2\A3:freetext
@@ -1581,6 +1725,10 @@ Free Text:SCT2\A3:freetext
 Free Text:SCT2\A3:freetext
 Free Text:SCT2\A3:freetext
 Free Text:SCT2\A3:freetext
+Free Text:SCT2\A3:freetext
+Free Text:SCT2\A3:freetext
+Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
@@ -1628,6 +1776,7 @@ Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
+Free Text:SCT2\A5:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
@@ -1641,6 +1790,7 @@ Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
+Free Text:SCT2\A7:freetext
 Free Text:SCT2\A7:freetext
 Free Text:SCT2\A7:freetext
 Free Text:SCT2\A7:freetext
@@ -1662,14 +1812,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1705,6 +1857,8 @@ Free Text:SCT2\B:freetext
 Free Text:SCT2\B:freetext
 Free Text:SCT2\B:freetext
 Free Text:SCT2\B:freetext
+Free Text:SCT2\B:freetext
+Free Text:SCT2\B:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
@@ -1747,6 +1901,14 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B2:freetext
+Free Text:SCT2\B2:freetext
+Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1798,6 +1960,11 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1810,18 +1977,26 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B7:freetext
+Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -1832,6 +2007,9 @@ Free Text:SCT2\BX:freetext
 Free Text:SCT2\BY1:freetext
 Free Text:SCT2\BY2:freetext
 Free Text:SCT2\BZ1:freetext
+Free Text:SCT2\C:freetext
+Free Text:SCT2\C:freetext
+Free Text:SCT2\C:freetext
 Free Text:SCT2\C:freetext
 Free Text:SCT2\C:freetext
 Free Text:SCT2\C:freetext
@@ -1901,6 +2079,9 @@ Free Text:SCT2\C1:freetext
 Free Text:SCT2\C1:freetext
 Free Text:SCT2\C1:freetext
 Free Text:SCT2\C1:freetext
+Free Text:SCT2\C1:freetext
+Free Text:SCT2\C2:freetext
+Free Text:SCT2\C2:freetext
 Free Text:SCT2\C2:freetext
 Free Text:SCT2\C2:freetext
 Free Text:SCT2\C2:freetext
@@ -1966,9 +2147,11 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
+Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
@@ -2030,6 +2213,11 @@ Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
+Free Text:SCT2\D2:freetext
+Free Text:SCT2\D2:freetext
+Free Text:SCT2\D2:freetext
+Free Text:SCT2\D3:freetext
+Free Text:SCT2\D3:freetext
 Free Text:SCT2\D3:freetext
 Free Text:SCT2\D3:freetext
 Free Text:SCT2\D3:freetext
@@ -2094,6 +2282,7 @@ Free Text:SCT2\E:freetext
 Free Text:SCT2\E:freetext
 Free Text:SCT2\E:freetext
 Free Text:SCT2\E:freetext
+Free Text:SCT2\E:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
@@ -2124,6 +2313,8 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
+Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2154,8 +2345,9 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2169,6 +2361,10 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
+Free Text:SCT2\F:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2225,22 +2421,17 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
 Free Text:SCT2\FX:freetext
 Free Text:SCT2\FZ1:freetext
-Free Text:SCT2\G:freetext
 Free Text:SCT2\G:freetext
 Free Text:SCT2\G:freetext
 Free Text:SCT2\G:freetext
@@ -2276,6 +2467,8 @@ Free Text:SCT2\G1:freetext
 Free Text:SCT2\G1:freetext
 Free Text:SCT2\G1:freetext
 Free Text:SCT2\G1:freetext
+Free Text:SCT2\G1:freetext
+Free Text:SCT2\G2:freetext
 Free Text:SCT2\G2:freetext
 Free Text:SCT2\G2:freetext
 Free Text:SCT2\G2:freetext
@@ -2300,6 +2493,8 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G3:freetext
 Free Text:SCT2\G3:freetext
 Free Text:SCT2\G3:freetext
+Free Text:SCT2\G3:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
@@ -2314,6 +2509,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2371,12 +2576,16 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2410,6 +2619,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2420,10 +2630,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2437,7 +2657,6 @@ Free Text:SCT2\J:freetext
 Free Text:SCT2\J:freetext
 Free Text:SCT2\J:freetext
 Free Text:SCT2\J:freetext
-Free Text:SCT2\J:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
@@ -2448,6 +2667,11 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2484,7 +2708,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2494,9 +2717,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2596,7 +2816,6 @@ Free Text:SCT2\M1:freetext
 Free Text:SCT2\M1:freetext
 Free Text:SCT2\M1:freetext
 Free Text:SCT2\M1:freetext
-Free Text:SCT2\M1:freetext
 Free Text:SCT2\M2:freetext
 Free Text:SCT2\M2:freetext
 Free Text:SCT2\M2:freetext
@@ -2649,12 +2868,14 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2667,22 +2888,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2765,6 +2981,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2790,6 +3007,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2799,6 +3017,8 @@ Free Text:SCT2\SQ5:freetext
 Free Text:SCT2\SY4:freetext
 Free Text:SCT2\SY5:freetext
 Free Text:SCT2\SY6:freetext
+Free Text:SCT2\T:freetext
+Free Text:SCT2\T:freetext
 Free Text:SCT2\T:freetext
 Free Text:SCT2\T:freetext
 Free Text:SCT2\T:freetext
@@ -2827,9 +3047,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2843,6 +3065,8 @@ Free Text:SCT2\TP-X:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -2889,6 +3113,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -2938,6 +3163,7 @@ Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y1:freetext
+Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y2:freetext
 Free Text:SCT2\Y2:freetext
 Free Text:SCT2\Y2:freetext
@@ -2952,9 +3178,13 @@ Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z1:freetext
+Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGCC Manchester:
 Regions:Manchester:polygon
 SHOWC:1

--- a/UK/Data/ASR/MPC/Manchester SMR.asr
+++ b/UK/Data/ASR/MPC/Manchester SMR.asr
@@ -53,7 +53,6 @@ Free Text:SCT2\ R :freetext
 Free Text:SCT2\ R :freetext
 Free Text:SCT2\ R :freetext
 Free Text:SCT2\ R :freetext
-Free Text:SCT2\03D:freetext
 Free Text:SCT2\06L:freetext
 Free Text:SCT2\06R:freetext
 Free Text:SCT2\07:freetext
@@ -96,6 +95,12 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -123,10 +128,10 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
-Free Text:SCT2\100:freetext
-Free Text:SCT2\101:freetext
 Free Text:SCT2\101:freetext
 Free Text:SCT2\101:freetext
 Free Text:SCT2\101:freetext
@@ -186,6 +191,7 @@ Free Text:SCT2\11:freetext
 Free Text:SCT2\11:freetext
 Free Text:SCT2\11:freetext
 Free Text:SCT2\11:freetext
+Free Text:SCT2\11:freetext
 Free Text:SCT2\110:freetext
 Free Text:SCT2\110:freetext
 Free Text:SCT2\111:freetext
@@ -198,6 +204,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -231,7 +238,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -304,6 +310,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -329,11 +336,16 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -359,6 +371,8 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
+Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -403,6 +417,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -440,6 +455,16 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -473,7 +498,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -501,6 +525,8 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -509,13 +535,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -523,6 +545,10 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -547,6 +573,7 @@ Free Text:SCT2\223:freetext
 Free Text:SCT2\224:freetext
 Free Text:SCT2\225:freetext
 Free Text:SCT2\226:freetext
+Free Text:SCT2\23:freetext
 Free Text:SCT2\23:freetext
 Free Text:SCT2\23:freetext
 Free Text:SCT2\23:freetext
@@ -594,6 +621,8 @@ Free Text:SCT2\24:freetext
 Free Text:SCT2\24:freetext
 Free Text:SCT2\24:freetext
 Free Text:SCT2\24:freetext
+Free Text:SCT2\24:freetext
+Free Text:SCT2\24:freetext
 Free Text:SCT2\241:freetext
 Free Text:SCT2\241:freetext
 Free Text:SCT2\242:freetext
@@ -618,6 +647,8 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -627,6 +658,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -636,7 +668,9 @@ Free Text:SCT2\26:freetext
 Free Text:SCT2\26:freetext
 Free Text:SCT2\26:freetext
 Free Text:SCT2\26:freetext
+Free Text:SCT2\26:freetext
 Free Text:SCT2\26S:freetext
+Free Text:SCT2\27:freetext
 Free Text:SCT2\27:freetext
 Free Text:SCT2\27:freetext
 Free Text:SCT2\27:freetext
@@ -653,13 +687,15 @@ Free Text:SCT2\28:freetext
 Free Text:SCT2\28:freetext
 Free Text:SCT2\28:freetext
 Free Text:SCT2\28:freetext
+Free Text:SCT2\28:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
-Free Text:SCT2\29A:freetext
+Free Text:SCT2\29:freetext
+Free Text:SCT2\2A:freetext
 Free Text:SCT2\2A:freetext
 Free Text:SCT2\2A:freetext
 Free Text:SCT2\2B:freetext
@@ -705,6 +741,13 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -729,6 +772,8 @@ Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
+Free Text:SCT2\31:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\310:freetext
 Free Text:SCT2\311:freetext
 Free Text:SCT2\311:freetext
@@ -744,7 +789,7 @@ Free Text:SCT2\317:freetext
 Free Text:SCT2\317A:freetext
 Free Text:SCT2\318:freetext
 Free Text:SCT2\319:freetext
-Free Text:SCT2\31R:freetext
+Free Text:SCT2\32:freetext
 Free Text:SCT2\32:freetext
 Free Text:SCT2\32:freetext
 Free Text:SCT2\32:freetext
@@ -771,13 +816,15 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
 Free Text:SCT2\334:freetext
 Free Text:SCT2\335:freetext
 Free Text:SCT2\336:freetext
-Free Text:SCT2\33L:freetext
+Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
@@ -785,6 +832,7 @@ Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
 Free Text:SCT2\340:freetext
 Free Text:SCT2\342:freetext
+Free Text:SCT2\35:freetext
 Free Text:SCT2\35:freetext
 Free Text:SCT2\35:freetext
 Free Text:SCT2\35:freetext
@@ -797,6 +845,7 @@ Free Text:SCT2\36:freetext
 Free Text:SCT2\36:freetext
 Free Text:SCT2\36:freetext
 Free Text:SCT2\36:freetext
+Free Text:SCT2\36:freetext
 Free Text:SCT2\363:freetext
 Free Text:SCT2\364:freetext
 Free Text:SCT2\365:freetext
@@ -804,12 +853,16 @@ Free Text:SCT2\37:freetext
 Free Text:SCT2\37:freetext
 Free Text:SCT2\37:freetext
 Free Text:SCT2\37:freetext
+Free Text:SCT2\37:freetext
+Free Text:SCT2\38:freetext
 Free Text:SCT2\38:freetext
 Free Text:SCT2\38:freetext
 Free Text:SCT2\38:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -845,6 +898,12 @@ Free Text:SCT2\4:freetext
 Free Text:SCT2\4:freetext
 Free Text:SCT2\4:freetext
 Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\40:freetext
 Free Text:SCT2\40:freetext
 Free Text:SCT2\40:freetext
 Free Text:SCT2\40:freetext
@@ -859,6 +918,7 @@ Free Text:SCT2\406:freetext
 Free Text:SCT2\407:freetext
 Free Text:SCT2\408:freetext
 Free Text:SCT2\409:freetext
+Free Text:SCT2\41:freetext
 Free Text:SCT2\41:freetext
 Free Text:SCT2\41:freetext
 Free Text:SCT2\41:freetext
@@ -896,9 +956,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -933,7 +995,6 @@ Free Text:SCT2\49:freetext
 Free Text:SCT2\49:freetext
 Free Text:SCT2\49:freetext
 Free Text:SCT2\4A:freetext
-Free Text:SCT2\4F:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
@@ -967,6 +1028,12 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -997,6 +1064,9 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1005,17 +1075,14 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1030,6 +1097,10 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1050,6 +1121,9 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1058,10 +1132,12 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
-Free Text:SCT2\551:freetext
+Free Text:SCT2\55:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\551:freetext
 Free Text:SCT2\552:freetext
 Free Text:SCT2\552:freetext
@@ -1080,6 +1156,7 @@ Free Text:SCT2\559:freetext
 Free Text:SCT2\55C:freetext
 Free Text:SCT2\55L:freetext
 Free Text:SCT2\55R:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
@@ -1103,6 +1180,8 @@ Free Text:SCT2\568:freetext
 Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1116,9 +1195,13 @@ Free Text:SCT2\57C:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
 Free Text:SCT2\591:freetext
@@ -1126,6 +1209,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1159,6 +1243,12 @@ Free Text:SCT2\6:freetext
 Free Text:SCT2\6:freetext
 Free Text:SCT2\6:freetext
 Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
@@ -1176,6 +1266,8 @@ Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\611:freetext
 Free Text:SCT2\612:freetext
 Free Text:SCT2\613:freetext
@@ -1186,9 +1278,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1197,17 +1296,26 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
+Free Text:SCT2\7:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1253,10 +1361,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1264,26 +1379,36 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
+Free Text:SCT2\8:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1323,7 +1448,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1376,6 +1503,10 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
+Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
 Free Text:SCT2\903:freetext
@@ -1383,19 +1514,23 @@ Free Text:SCT2\905:freetext
 Free Text:SCT2\907:freetext
 Free Text:SCT2\909:freetext
 Free Text:SCT2\91:freetext
+Free Text:SCT2\91:freetext
 Free Text:SCT2\911:freetext
 Free Text:SCT2\913:freetext
 Free Text:SCT2\915:freetext
 Free Text:SCT2\917:freetext
 Free Text:SCT2\919:freetext
 Free Text:SCT2\92:freetext
+Free Text:SCT2\92:freetext
 Free Text:SCT2\925:freetext
 Free Text:SCT2\927:freetext
 Free Text:SCT2\929:freetext
 Free Text:SCT2\93:freetext
+Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1423,6 +1558,12 @@ Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
+Free Text:SCT2\A:freetext
+Free Text:SCT2\A:freetext
+Free Text:SCT2\A:freetext
+Free Text:SCT2\A1:freetext
+Free Text:SCT2\A1:freetext
+Free Text:SCT2\A1:freetext
 Free Text:SCT2\A1:freetext
 Free Text:SCT2\A1:freetext
 Free Text:SCT2\A1:freetext
@@ -1538,6 +1679,9 @@ Free Text:SCT2\A2:freetext
 Free Text:SCT2\A2:freetext
 Free Text:SCT2\A2:freetext
 Free Text:SCT2\A2:freetext
+Free Text:SCT2\A2:freetext
+Free Text:SCT2\A2:freetext
+Free Text:SCT2\A2:freetext
 Free Text:SCT2\A20:freetext
 Free Text:SCT2\A24:freetext
 Free Text:SCT2\A3:freetext
@@ -1581,6 +1725,10 @@ Free Text:SCT2\A3:freetext
 Free Text:SCT2\A3:freetext
 Free Text:SCT2\A3:freetext
 Free Text:SCT2\A3:freetext
+Free Text:SCT2\A3:freetext
+Free Text:SCT2\A3:freetext
+Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
@@ -1628,6 +1776,7 @@ Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
+Free Text:SCT2\A5:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
@@ -1641,6 +1790,7 @@ Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
+Free Text:SCT2\A7:freetext
 Free Text:SCT2\A7:freetext
 Free Text:SCT2\A7:freetext
 Free Text:SCT2\A7:freetext
@@ -1662,14 +1812,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1705,6 +1857,8 @@ Free Text:SCT2\B:freetext
 Free Text:SCT2\B:freetext
 Free Text:SCT2\B:freetext
 Free Text:SCT2\B:freetext
+Free Text:SCT2\B:freetext
+Free Text:SCT2\B:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
@@ -1747,6 +1901,14 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B2:freetext
+Free Text:SCT2\B2:freetext
+Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1798,6 +1960,11 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1810,18 +1977,26 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B7:freetext
+Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -1832,6 +2007,9 @@ Free Text:SCT2\BX:freetext
 Free Text:SCT2\BY1:freetext
 Free Text:SCT2\BY2:freetext
 Free Text:SCT2\BZ1:freetext
+Free Text:SCT2\C:freetext
+Free Text:SCT2\C:freetext
+Free Text:SCT2\C:freetext
 Free Text:SCT2\C:freetext
 Free Text:SCT2\C:freetext
 Free Text:SCT2\C:freetext
@@ -1901,6 +2079,9 @@ Free Text:SCT2\C1:freetext
 Free Text:SCT2\C1:freetext
 Free Text:SCT2\C1:freetext
 Free Text:SCT2\C1:freetext
+Free Text:SCT2\C1:freetext
+Free Text:SCT2\C2:freetext
+Free Text:SCT2\C2:freetext
 Free Text:SCT2\C2:freetext
 Free Text:SCT2\C2:freetext
 Free Text:SCT2\C2:freetext
@@ -1966,9 +2147,11 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
+Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
@@ -2030,6 +2213,11 @@ Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
+Free Text:SCT2\D2:freetext
+Free Text:SCT2\D2:freetext
+Free Text:SCT2\D2:freetext
+Free Text:SCT2\D3:freetext
+Free Text:SCT2\D3:freetext
 Free Text:SCT2\D3:freetext
 Free Text:SCT2\D3:freetext
 Free Text:SCT2\D3:freetext
@@ -2094,6 +2282,7 @@ Free Text:SCT2\E:freetext
 Free Text:SCT2\E:freetext
 Free Text:SCT2\E:freetext
 Free Text:SCT2\E:freetext
+Free Text:SCT2\E:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
@@ -2124,6 +2313,8 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
+Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2154,8 +2345,9 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2169,6 +2361,10 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
+Free Text:SCT2\F:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2225,22 +2421,17 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
 Free Text:SCT2\FX:freetext
 Free Text:SCT2\FZ1:freetext
-Free Text:SCT2\G:freetext
 Free Text:SCT2\G:freetext
 Free Text:SCT2\G:freetext
 Free Text:SCT2\G:freetext
@@ -2276,6 +2467,8 @@ Free Text:SCT2\G1:freetext
 Free Text:SCT2\G1:freetext
 Free Text:SCT2\G1:freetext
 Free Text:SCT2\G1:freetext
+Free Text:SCT2\G1:freetext
+Free Text:SCT2\G2:freetext
 Free Text:SCT2\G2:freetext
 Free Text:SCT2\G2:freetext
 Free Text:SCT2\G2:freetext
@@ -2300,6 +2493,8 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G3:freetext
 Free Text:SCT2\G3:freetext
 Free Text:SCT2\G3:freetext
+Free Text:SCT2\G3:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
@@ -2314,6 +2509,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2371,12 +2576,16 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2410,6 +2619,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2420,10 +2630,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2437,7 +2657,6 @@ Free Text:SCT2\J:freetext
 Free Text:SCT2\J:freetext
 Free Text:SCT2\J:freetext
 Free Text:SCT2\J:freetext
-Free Text:SCT2\J:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
@@ -2448,6 +2667,11 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2484,7 +2708,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2494,9 +2717,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2596,7 +2816,6 @@ Free Text:SCT2\M1:freetext
 Free Text:SCT2\M1:freetext
 Free Text:SCT2\M1:freetext
 Free Text:SCT2\M1:freetext
-Free Text:SCT2\M1:freetext
 Free Text:SCT2\M2:freetext
 Free Text:SCT2\M2:freetext
 Free Text:SCT2\M2:freetext
@@ -2649,12 +2868,14 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2667,22 +2888,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2765,6 +2981,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2790,6 +3007,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2799,6 +3017,8 @@ Free Text:SCT2\SQ5:freetext
 Free Text:SCT2\SY4:freetext
 Free Text:SCT2\SY5:freetext
 Free Text:SCT2\SY6:freetext
+Free Text:SCT2\T:freetext
+Free Text:SCT2\T:freetext
 Free Text:SCT2\T:freetext
 Free Text:SCT2\T:freetext
 Free Text:SCT2\T:freetext
@@ -2827,9 +3047,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2843,6 +3065,8 @@ Free Text:SCT2\TP-X:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -2889,6 +3113,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -2938,6 +3163,7 @@ Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y1:freetext
+Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y2:freetext
 Free Text:SCT2\Y2:freetext
 Free Text:SCT2\Y2:freetext
@@ -2952,9 +3178,13 @@ Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z1:freetext
+Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGCC Manchester:
 Regions:Manchester:polygon
 SHOWC:1

--- a/UK/Data/ASR/Manchester/Manchester SMR.asr
+++ b/UK/Data/ASR/Manchester/Manchester SMR.asr
@@ -53,7 +53,6 @@ Free Text:SCT2\ R :freetext
 Free Text:SCT2\ R :freetext
 Free Text:SCT2\ R :freetext
 Free Text:SCT2\ R :freetext
-Free Text:SCT2\03D:freetext
 Free Text:SCT2\06L:freetext
 Free Text:SCT2\06R:freetext
 Free Text:SCT2\07:freetext
@@ -96,6 +95,12 @@ Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
 Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
+Free Text:SCT2\1:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
@@ -123,10 +128,10 @@ Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
 Free Text:SCT2\10:freetext
+Free Text:SCT2\10:freetext
+Free Text:SCT2\10 :freetext
 Free Text:SCT2\100:freetext
 Free Text:SCT2\100:freetext
-Free Text:SCT2\100:freetext
-Free Text:SCT2\101:freetext
 Free Text:SCT2\101:freetext
 Free Text:SCT2\101:freetext
 Free Text:SCT2\101:freetext
@@ -186,6 +191,7 @@ Free Text:SCT2\11:freetext
 Free Text:SCT2\11:freetext
 Free Text:SCT2\11:freetext
 Free Text:SCT2\11:freetext
+Free Text:SCT2\11:freetext
 Free Text:SCT2\110:freetext
 Free Text:SCT2\110:freetext
 Free Text:SCT2\111:freetext
@@ -198,6 +204,7 @@ Free Text:SCT2\113:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\114:freetext
 Free Text:SCT2\116:freetext
+Free Text:SCT2\11A:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
 Free Text:SCT2\12:freetext
@@ -231,7 +238,6 @@ Free Text:SCT2\125:freetext
 Free Text:SCT2\125R:freetext
 Free Text:SCT2\12L:freetext
 Free Text:SCT2\12R:freetext
-Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
 Free Text:SCT2\13:freetext
@@ -304,6 +310,7 @@ Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
 Free Text:SCT2\15:freetext
+Free Text:SCT2\15:freetext
 Free Text:SCT2\150:freetext
 Free Text:SCT2\151:freetext
 Free Text:SCT2\152:freetext
@@ -329,11 +336,16 @@ Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
 Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
+Free Text:SCT2\16:freetext
 Free Text:SCT2\160:freetext
 Free Text:SCT2\161:freetext
 Free Text:SCT2\16A:freetext
+Free Text:SCT2\16A:freetext
 Free Text:SCT2\16L:freetext
 Free Text:SCT2\16R:freetext
+Free Text:SCT2\17:freetext
+Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
 Free Text:SCT2\17:freetext
@@ -359,6 +371,8 @@ Free Text:SCT2\175:freetext
 Free Text:SCT2\176:freetext
 Free Text:SCT2\177:freetext
 Free Text:SCT2\178:freetext
+Free Text:SCT2\17A:freetext
+Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
 Free Text:SCT2\18:freetext
@@ -403,6 +417,7 @@ Free Text:SCT2\1L:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
 Free Text:SCT2\1R:freetext
+Free Text:SCT2\1R:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
@@ -440,6 +455,16 @@ Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
 Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\2:freetext
+Free Text:SCT2\20:freetext
+Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
 Free Text:SCT2\20:freetext
@@ -473,7 +498,6 @@ Free Text:SCT2\204:freetext
 Free Text:SCT2\204:freetext
 Free Text:SCT2\205:freetext
 Free Text:SCT2\205:freetext
-Free Text:SCT2\205:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\206:freetext
 Free Text:SCT2\207:freetext
@@ -501,6 +525,8 @@ Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
 Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
+Free Text:SCT2\21:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
 Free Text:SCT2\210:freetext
@@ -509,13 +535,9 @@ Free Text:SCT2\211:freetext
 Free Text:SCT2\211:freetext
 Free Text:SCT2\212:freetext
 Free Text:SCT2\212:freetext
-Free Text:SCT2\212:freetext
-Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\213:freetext
 Free Text:SCT2\214:freetext
-Free Text:SCT2\214:freetext
-Free Text:SCT2\215:freetext
 Free Text:SCT2\216:freetext
 Free Text:SCT2\217:freetext
 Free Text:SCT2\218:freetext
@@ -523,6 +545,10 @@ Free Text:SCT2\219:freetext
 Free Text:SCT2\21A:freetext
 Free Text:SCT2\21B:freetext
 Free Text:SCT2\21C:freetext
+Free Text:SCT2\21E:freetext
+Free Text:SCT2\21W:freetext
+Free Text:SCT2\22:freetext
+Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
 Free Text:SCT2\22:freetext
@@ -547,6 +573,7 @@ Free Text:SCT2\223:freetext
 Free Text:SCT2\224:freetext
 Free Text:SCT2\225:freetext
 Free Text:SCT2\226:freetext
+Free Text:SCT2\23:freetext
 Free Text:SCT2\23:freetext
 Free Text:SCT2\23:freetext
 Free Text:SCT2\23:freetext
@@ -594,6 +621,8 @@ Free Text:SCT2\24:freetext
 Free Text:SCT2\24:freetext
 Free Text:SCT2\24:freetext
 Free Text:SCT2\24:freetext
+Free Text:SCT2\24:freetext
+Free Text:SCT2\24:freetext
 Free Text:SCT2\241:freetext
 Free Text:SCT2\241:freetext
 Free Text:SCT2\242:freetext
@@ -618,6 +647,8 @@ Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
 Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
+Free Text:SCT2\25:freetext
 Free Text:SCT2\251:freetext
 Free Text:SCT2\252:freetext
 Free Text:SCT2\253:freetext
@@ -627,6 +658,7 @@ Free Text:SCT2\256:freetext
 Free Text:SCT2\257:freetext
 Free Text:SCT2\258:freetext
 Free Text:SCT2\25A:freetext
+Free Text:SCT2\25B:freetext
 Free Text:SCT2\25L:freetext
 Free Text:SCT2\25R:freetext
 Free Text:SCT2\26:freetext
@@ -636,7 +668,9 @@ Free Text:SCT2\26:freetext
 Free Text:SCT2\26:freetext
 Free Text:SCT2\26:freetext
 Free Text:SCT2\26:freetext
+Free Text:SCT2\26:freetext
 Free Text:SCT2\26S:freetext
+Free Text:SCT2\27:freetext
 Free Text:SCT2\27:freetext
 Free Text:SCT2\27:freetext
 Free Text:SCT2\27:freetext
@@ -653,13 +687,15 @@ Free Text:SCT2\28:freetext
 Free Text:SCT2\28:freetext
 Free Text:SCT2\28:freetext
 Free Text:SCT2\28:freetext
+Free Text:SCT2\28:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
 Free Text:SCT2\29:freetext
-Free Text:SCT2\29A:freetext
+Free Text:SCT2\29:freetext
+Free Text:SCT2\2A:freetext
 Free Text:SCT2\2A:freetext
 Free Text:SCT2\2A:freetext
 Free Text:SCT2\2B:freetext
@@ -705,6 +741,13 @@ Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
 Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\3:freetext
+Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
 Free Text:SCT2\30:freetext
@@ -729,6 +772,8 @@ Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
 Free Text:SCT2\31:freetext
+Free Text:SCT2\31:freetext
+Free Text:SCT2\31:freetext
 Free Text:SCT2\310:freetext
 Free Text:SCT2\311:freetext
 Free Text:SCT2\311:freetext
@@ -744,7 +789,7 @@ Free Text:SCT2\317:freetext
 Free Text:SCT2\317A:freetext
 Free Text:SCT2\318:freetext
 Free Text:SCT2\319:freetext
-Free Text:SCT2\31R:freetext
+Free Text:SCT2\32:freetext
 Free Text:SCT2\32:freetext
 Free Text:SCT2\32:freetext
 Free Text:SCT2\32:freetext
@@ -771,13 +816,15 @@ Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
 Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
+Free Text:SCT2\33:freetext
 Free Text:SCT2\330:freetext
 Free Text:SCT2\331:freetext
 Free Text:SCT2\332:freetext
 Free Text:SCT2\334:freetext
 Free Text:SCT2\335:freetext
 Free Text:SCT2\336:freetext
-Free Text:SCT2\33L:freetext
+Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
@@ -785,6 +832,7 @@ Free Text:SCT2\34:freetext
 Free Text:SCT2\34:freetext
 Free Text:SCT2\340:freetext
 Free Text:SCT2\342:freetext
+Free Text:SCT2\35:freetext
 Free Text:SCT2\35:freetext
 Free Text:SCT2\35:freetext
 Free Text:SCT2\35:freetext
@@ -797,6 +845,7 @@ Free Text:SCT2\36:freetext
 Free Text:SCT2\36:freetext
 Free Text:SCT2\36:freetext
 Free Text:SCT2\36:freetext
+Free Text:SCT2\36:freetext
 Free Text:SCT2\363:freetext
 Free Text:SCT2\364:freetext
 Free Text:SCT2\365:freetext
@@ -804,12 +853,16 @@ Free Text:SCT2\37:freetext
 Free Text:SCT2\37:freetext
 Free Text:SCT2\37:freetext
 Free Text:SCT2\37:freetext
+Free Text:SCT2\37:freetext
+Free Text:SCT2\38:freetext
 Free Text:SCT2\38:freetext
 Free Text:SCT2\38:freetext
 Free Text:SCT2\38:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
 Free Text:SCT2\39:freetext
+Free Text:SCT2\39:freetext
+Free Text:SCT2\3A:freetext
 Free Text:SCT2\3F:freetext
 Free Text:SCT2\3R:freetext
 Free Text:SCT2\4:freetext
@@ -845,6 +898,12 @@ Free Text:SCT2\4:freetext
 Free Text:SCT2\4:freetext
 Free Text:SCT2\4:freetext
 Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\4:freetext
+Free Text:SCT2\40:freetext
 Free Text:SCT2\40:freetext
 Free Text:SCT2\40:freetext
 Free Text:SCT2\40:freetext
@@ -859,6 +918,7 @@ Free Text:SCT2\406:freetext
 Free Text:SCT2\407:freetext
 Free Text:SCT2\408:freetext
 Free Text:SCT2\409:freetext
+Free Text:SCT2\41:freetext
 Free Text:SCT2\41:freetext
 Free Text:SCT2\41:freetext
 Free Text:SCT2\41:freetext
@@ -896,9 +956,11 @@ Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
 Free Text:SCT2\43:freetext
+Free Text:SCT2\43:freetext
 Free Text:SCT2\430:freetext
 Free Text:SCT2\431:freetext
 Free Text:SCT2\432:freetext
+Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
 Free Text:SCT2\44:freetext
@@ -933,7 +995,6 @@ Free Text:SCT2\49:freetext
 Free Text:SCT2\49:freetext
 Free Text:SCT2\49:freetext
 Free Text:SCT2\4A:freetext
-Free Text:SCT2\4F:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
@@ -967,6 +1028,12 @@ Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
 Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\5:freetext
+Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
 Free Text:SCT2\50:freetext
@@ -997,6 +1064,9 @@ Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
 Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
+Free Text:SCT2\51:freetext
 Free Text:SCT2\510:freetext
 Free Text:SCT2\511:freetext
 Free Text:SCT2\511:freetext
@@ -1005,17 +1075,14 @@ Free Text:SCT2\512:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\513:freetext
 Free Text:SCT2\514:freetext
-Free Text:SCT2\514:freetext
-Free Text:SCT2\515:freetext
 Free Text:SCT2\515:freetext
 Free Text:SCT2\516:freetext
-Free Text:SCT2\516:freetext
-Free Text:SCT2\517:freetext
 Free Text:SCT2\517:freetext
 Free Text:SCT2\518:freetext
-Free Text:SCT2\518:freetext
 Free Text:SCT2\519:freetext
-Free Text:SCT2\519:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
+Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
 Free Text:SCT2\52:freetext
@@ -1030,6 +1097,10 @@ Free Text:SCT2\524:freetext
 Free Text:SCT2\525:freetext
 Free Text:SCT2\526:freetext
 Free Text:SCT2\527:freetext
+Free Text:SCT2\52A:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
+Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
 Free Text:SCT2\53:freetext
@@ -1050,6 +1121,9 @@ Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
 Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
+Free Text:SCT2\54:freetext
 Free Text:SCT2\541:freetext
 Free Text:SCT2\542:freetext
 Free Text:SCT2\543:freetext
@@ -1058,10 +1132,12 @@ Free Text:SCT2\545:freetext
 Free Text:SCT2\546:freetext
 Free Text:SCT2\547:freetext
 Free Text:SCT2\548:freetext
+Free Text:SCT2\54A:freetext
 Free Text:SCT2\54C:freetext
 Free Text:SCT2\55:freetext
 Free Text:SCT2\55:freetext
-Free Text:SCT2\551:freetext
+Free Text:SCT2\55:freetext
+Free Text:SCT2\55:freetext
 Free Text:SCT2\551:freetext
 Free Text:SCT2\552:freetext
 Free Text:SCT2\552:freetext
@@ -1080,6 +1156,7 @@ Free Text:SCT2\559:freetext
 Free Text:SCT2\55C:freetext
 Free Text:SCT2\55L:freetext
 Free Text:SCT2\55R:freetext
+Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
 Free Text:SCT2\56:freetext
@@ -1103,6 +1180,8 @@ Free Text:SCT2\568:freetext
 Free Text:SCT2\569:freetext
 Free Text:SCT2\56C:freetext
 Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
+Free Text:SCT2\57:freetext
 Free Text:SCT2\570:freetext
 Free Text:SCT2\571:freetext
 Free Text:SCT2\572:freetext
@@ -1116,9 +1195,13 @@ Free Text:SCT2\57C:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
 Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
+Free Text:SCT2\58:freetext
 Free Text:SCT2\581:freetext
 Free Text:SCT2\582:freetext
 Free Text:SCT2\583:freetext
+Free Text:SCT2\59:freetext
+Free Text:SCT2\59:freetext
 Free Text:SCT2\59:freetext
 Free Text:SCT2\590:freetext
 Free Text:SCT2\591:freetext
@@ -1126,6 +1209,7 @@ Free Text:SCT2\592:freetext
 Free Text:SCT2\594:freetext
 Free Text:SCT2\595:freetext
 Free Text:SCT2\596:freetext
+Free Text:SCT2\5A:freetext
 Free Text:SCT2\5F:freetext
 Free Text:SCT2\5R:freetext
 Free Text:SCT2\6:freetext
@@ -1159,6 +1243,12 @@ Free Text:SCT2\6:freetext
 Free Text:SCT2\6:freetext
 Free Text:SCT2\6:freetext
 Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\6:freetext
+Free Text:SCT2\60:freetext
+Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
 Free Text:SCT2\60:freetext
@@ -1176,6 +1266,8 @@ Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
 Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
+Free Text:SCT2\61:freetext
 Free Text:SCT2\611:freetext
 Free Text:SCT2\612:freetext
 Free Text:SCT2\613:freetext
@@ -1186,9 +1278,16 @@ Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
 Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
+Free Text:SCT2\62:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
 Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\63:freetext
+Free Text:SCT2\64:freetext
+Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
 Free Text:SCT2\64:freetext
@@ -1197,17 +1296,26 @@ Free Text:SCT2\64R:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
 Free Text:SCT2\65:freetext
+Free Text:SCT2\65:freetext
 Free Text:SCT2\65L:freetext
 Free Text:SCT2\65R:freetext
 Free Text:SCT2\66:freetext
 Free Text:SCT2\66:freetext
+Free Text:SCT2\66:freetext
 Free Text:SCT2\67:freetext
 Free Text:SCT2\67:freetext
+Free Text:SCT2\67:freetext
+Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\68:freetext
 Free Text:SCT2\69:freetext
+Free Text:SCT2\69:freetext
+Free Text:SCT2\6A:freetext
 Free Text:SCT2\6A:freetext
 Free Text:SCT2\6F:freetext
+Free Text:SCT2\7:freetext
+Free Text:SCT2\7:freetext
+Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
 Free Text:SCT2\7:freetext
@@ -1253,10 +1361,17 @@ Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
 Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
+Free Text:SCT2\71:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
 Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\72:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
+Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
 Free Text:SCT2\73:freetext
@@ -1264,26 +1379,36 @@ Free Text:SCT2\73L:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
 Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
+Free Text:SCT2\74:freetext
 Free Text:SCT2\74L:freetext
 Free Text:SCT2\75:freetext
 Free Text:SCT2\75:freetext
+Free Text:SCT2\75:freetext
 Free Text:SCT2\75R:freetext
+Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76:freetext
 Free Text:SCT2\76L:freetext
 Free Text:SCT2\76R:freetext
 Free Text:SCT2\77:freetext
 Free Text:SCT2\77:freetext
+Free Text:SCT2\77:freetext
 Free Text:SCT2\77L:freetext
 Free Text:SCT2\77R:freetext
+Free Text:SCT2\78:freetext
 Free Text:SCT2\78:freetext
 Free Text:SCT2\78L:freetext
 Free Text:SCT2\78R:freetext
 Free Text:SCT2\78X:freetext
 Free Text:SCT2\79:freetext
+Free Text:SCT2\79:freetext
 Free Text:SCT2\7A:freetext
 Free Text:SCT2\7L:freetext
 Free Text:SCT2\7N:freetext
+Free Text:SCT2\8:freetext
+Free Text:SCT2\8:freetext
+Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
 Free Text:SCT2\8:freetext
@@ -1323,7 +1448,9 @@ Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
 Free Text:SCT2\81:freetext
+Free Text:SCT2\81:freetext
 Free Text:SCT2\811:freetext
+Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
 Free Text:SCT2\82:freetext
@@ -1376,6 +1503,10 @@ Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
 Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
+Free Text:SCT2\9:freetext
+Free Text:SCT2\90:freetext
 Free Text:SCT2\90:freetext
 Free Text:SCT2\901:freetext
 Free Text:SCT2\903:freetext
@@ -1383,19 +1514,23 @@ Free Text:SCT2\905:freetext
 Free Text:SCT2\907:freetext
 Free Text:SCT2\909:freetext
 Free Text:SCT2\91:freetext
+Free Text:SCT2\91:freetext
 Free Text:SCT2\911:freetext
 Free Text:SCT2\913:freetext
 Free Text:SCT2\915:freetext
 Free Text:SCT2\917:freetext
 Free Text:SCT2\919:freetext
 Free Text:SCT2\92:freetext
+Free Text:SCT2\92:freetext
 Free Text:SCT2\925:freetext
 Free Text:SCT2\927:freetext
 Free Text:SCT2\929:freetext
 Free Text:SCT2\93:freetext
+Free Text:SCT2\93:freetext
 Free Text:SCT2\98:freetext
 Free Text:SCT2\99:freetext
 Free Text:SCT2\9A:freetext
+Free Text:SCT2\9L:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
@@ -1423,6 +1558,12 @@ Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
 Free Text:SCT2\A:freetext
+Free Text:SCT2\A:freetext
+Free Text:SCT2\A:freetext
+Free Text:SCT2\A:freetext
+Free Text:SCT2\A1:freetext
+Free Text:SCT2\A1:freetext
+Free Text:SCT2\A1:freetext
 Free Text:SCT2\A1:freetext
 Free Text:SCT2\A1:freetext
 Free Text:SCT2\A1:freetext
@@ -1538,6 +1679,9 @@ Free Text:SCT2\A2:freetext
 Free Text:SCT2\A2:freetext
 Free Text:SCT2\A2:freetext
 Free Text:SCT2\A2:freetext
+Free Text:SCT2\A2:freetext
+Free Text:SCT2\A2:freetext
+Free Text:SCT2\A2:freetext
 Free Text:SCT2\A20:freetext
 Free Text:SCT2\A24:freetext
 Free Text:SCT2\A3:freetext
@@ -1581,6 +1725,10 @@ Free Text:SCT2\A3:freetext
 Free Text:SCT2\A3:freetext
 Free Text:SCT2\A3:freetext
 Free Text:SCT2\A3:freetext
+Free Text:SCT2\A3:freetext
+Free Text:SCT2\A3:freetext
+Free Text:SCT2\A4:freetext
+Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
 Free Text:SCT2\A4:freetext
@@ -1628,6 +1776,7 @@ Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
 Free Text:SCT2\A5:freetext
+Free Text:SCT2\A5:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
@@ -1641,6 +1790,7 @@ Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
 Free Text:SCT2\A6:freetext
+Free Text:SCT2\A7:freetext
 Free Text:SCT2\A7:freetext
 Free Text:SCT2\A7:freetext
 Free Text:SCT2\A7:freetext
@@ -1662,14 +1812,16 @@ Free Text:SCT2\AB13:freetext
 Free Text:SCT2\AE2:freetext
 Free Text:SCT2\AF1:freetext
 Free Text:SCT2\AG1:freetext
+Free Text:SCT2\Aircraft Parking:freetext
 Free Text:SCT2\AL1:freetext
 Free Text:SCT2\AL2:freetext
+Free Text:SCT2\Apron:freetext
 Free Text:SCT2\Apron 1:freetext
 Free Text:SCT2\Apron 2:freetext
 Free Text:SCT2\Apron 3:freetext
+Free Text:SCT2\Apron 4:freetext
 Free Text:SCT2\ASP A:freetext
 Free Text:SCT2\ASP B:freetext
-Free Text:SCT2\ATC:freetext
 Free Text:SCT2\AVROE:freetext
 Free Text:SCT2\AW2:freetext
 Free Text:SCT2\AX:freetext
@@ -1705,6 +1857,8 @@ Free Text:SCT2\B:freetext
 Free Text:SCT2\B:freetext
 Free Text:SCT2\B:freetext
 Free Text:SCT2\B:freetext
+Free Text:SCT2\B:freetext
+Free Text:SCT2\B:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
@@ -1747,6 +1901,14 @@ Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
 Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B1:freetext
+Free Text:SCT2\B2:freetext
+Free Text:SCT2\B2:freetext
+Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
 Free Text:SCT2\B2:freetext
@@ -1798,6 +1960,11 @@ Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
 Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B3:freetext
+Free Text:SCT2\B4:freetext
+Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
 Free Text:SCT2\B4:freetext
@@ -1810,18 +1977,26 @@ Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
 Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B5:freetext
+Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B6:freetext
 Free Text:SCT2\B7:freetext
+Free Text:SCT2\B7:freetext
 Free Text:SCT2\B747:freetext
 Free Text:SCT2\B8:freetext
 Free Text:SCT2\Bay 1:freetext
+Free Text:SCT2\Bay 10:freetext
 Free Text:SCT2\Bay 2:freetext
 Free Text:SCT2\Bay 3:freetext
 Free Text:SCT2\Bay 4:freetext
 Free Text:SCT2\Bay 5:freetext
 Free Text:SCT2\Bay 6:freetext
+Free Text:SCT2\Bay 7:freetext
+Free Text:SCT2\Bay 8:freetext
+Free Text:SCT2\Bay 9:freetext
 Free Text:SCT2\Belfast Apron:freetext
 Free Text:SCT2\BL1:freetext
 Free Text:SCT2\BL2:freetext
@@ -1832,6 +2007,9 @@ Free Text:SCT2\BX:freetext
 Free Text:SCT2\BY1:freetext
 Free Text:SCT2\BY2:freetext
 Free Text:SCT2\BZ1:freetext
+Free Text:SCT2\C:freetext
+Free Text:SCT2\C:freetext
+Free Text:SCT2\C:freetext
 Free Text:SCT2\C:freetext
 Free Text:SCT2\C:freetext
 Free Text:SCT2\C:freetext
@@ -1901,6 +2079,9 @@ Free Text:SCT2\C1:freetext
 Free Text:SCT2\C1:freetext
 Free Text:SCT2\C1:freetext
 Free Text:SCT2\C1:freetext
+Free Text:SCT2\C1:freetext
+Free Text:SCT2\C2:freetext
+Free Text:SCT2\C2:freetext
 Free Text:SCT2\C2:freetext
 Free Text:SCT2\C2:freetext
 Free Text:SCT2\C2:freetext
@@ -1966,9 +2147,11 @@ Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
 Free Text:SCT2\D:freetext
-Free Text:SCT2\D:freetext
 Free Text:SCT2\D-Site Apron:freetext
 Free Text:SCT2\D0:freetext
+Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
+Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
 Free Text:SCT2\D1:freetext
@@ -2030,6 +2213,11 @@ Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
 Free Text:SCT2\D2:freetext
+Free Text:SCT2\D2:freetext
+Free Text:SCT2\D2:freetext
+Free Text:SCT2\D2:freetext
+Free Text:SCT2\D3:freetext
+Free Text:SCT2\D3:freetext
 Free Text:SCT2\D3:freetext
 Free Text:SCT2\D3:freetext
 Free Text:SCT2\D3:freetext
@@ -2094,6 +2282,7 @@ Free Text:SCT2\E:freetext
 Free Text:SCT2\E:freetext
 Free Text:SCT2\E:freetext
 Free Text:SCT2\E:freetext
+Free Text:SCT2\E:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
@@ -2124,6 +2313,8 @@ Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
 Free Text:SCT2\E1:freetext
+Free Text:SCT2\E10:freetext
+Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
 Free Text:SCT2\E2:freetext
@@ -2154,8 +2345,9 @@ Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
+Free Text:SCT2\E3:freetext
 Free Text:SCT2\E3A:freetext
-Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E4:freetext
 Free Text:SCT2\E5:freetext
@@ -2169,6 +2361,10 @@ Free Text:SCT2\E9:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\East Apron:freetext
 Free Text:SCT2\Eastern Apron:freetext
+Free Text:SCT2\ER:freetext
+Free Text:SCT2\F:freetext
+Free Text:SCT2\F:freetext
+Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
 Free Text:SCT2\F:freetext
@@ -2225,22 +2421,17 @@ Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
 Free Text:SCT2\F3:freetext
-Free Text:SCT2\F3:freetext
-Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F4:freetext
 Free Text:SCT2\F5:freetext
 Free Text:SCT2\FA1:freetext
-Free Text:SCT2\FCL:freetext
 Free Text:SCT2\FR:freetext
-Free Text:SCT2\FS:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\Fuel:freetext
 Free Text:SCT2\FX:freetext
 Free Text:SCT2\FX:freetext
 Free Text:SCT2\FZ1:freetext
-Free Text:SCT2\G:freetext
 Free Text:SCT2\G:freetext
 Free Text:SCT2\G:freetext
 Free Text:SCT2\G:freetext
@@ -2276,6 +2467,8 @@ Free Text:SCT2\G1:freetext
 Free Text:SCT2\G1:freetext
 Free Text:SCT2\G1:freetext
 Free Text:SCT2\G1:freetext
+Free Text:SCT2\G1:freetext
+Free Text:SCT2\G2:freetext
 Free Text:SCT2\G2:freetext
 Free Text:SCT2\G2:freetext
 Free Text:SCT2\G2:freetext
@@ -2300,6 +2493,8 @@ Free Text:SCT2\G3:freetext
 Free Text:SCT2\G3:freetext
 Free Text:SCT2\G3:freetext
 Free Text:SCT2\G3:freetext
+Free Text:SCT2\G3:freetext
+Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
 Free Text:SCT2\G4:freetext
@@ -2314,6 +2509,16 @@ Free Text:SCT2\Grass Apron:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\Grass Parking:freetext
 Free Text:SCT2\GX:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
+Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
 Free Text:SCT2\H:freetext
@@ -2371,12 +2576,16 @@ Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
 Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
+Free Text:SCT2\H1:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H10:freetext
 Free Text:SCT2\H11:freetext
 Free Text:SCT2\H12:freetext
 Free Text:SCT2\H1N:freetext
 Free Text:SCT2\H1S:freetext
+Free Text:SCT2\H2:freetext
+Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
 Free Text:SCT2\H2:freetext
@@ -2410,6 +2619,7 @@ Free Text:SCT2\H9:freetext
 Free Text:SCT2\Hangar 1:freetext
 Free Text:SCT2\Hangar 2:freetext
 Free Text:SCT2\HANLI:freetext
+Free Text:SCT2\HAP:freetext
 Free Text:SCT2\Heli 1:freetext
 Free Text:SCT2\Heli 2:freetext
 Free Text:SCT2\Heli 3:freetext
@@ -2420,10 +2630,20 @@ Free Text:SCT2\Heli 7:freetext
 Free Text:SCT2\Heli A:freetext
 Free Text:SCT2\Heli B:freetext
 Free Text:SCT2\Heli E:freetext
+Free Text:SCT2\Heli East:freetext
 Free Text:SCT2\Heli N:freetext
+Free Text:SCT2\Heli North:freetext
 Free Text:SCT2\Heli S:freetext
+Free Text:SCT2\Heli South:freetext
 Free Text:SCT2\Heli W:freetext
+Free Text:SCT2\Heli West:freetext
+Free Text:SCT2\Helicoper Hoversquare:freetext
+Free Text:SCT2\Heliport:freetext
 Free Text:SCT2\HORKA:freetext
+Free Text:SCT2\HTA 1:freetext
+Free Text:SCT2\HTA 2:freetext
+Free Text:SCT2\HTA 3:freetext
+Free Text:SCT2\HTA 4:freetext
 Free Text:SCT2\HTA-N:freetext
 Free Text:SCT2\HX:freetext
 Free Text:SCT2\HZ1:freetext
@@ -2437,7 +2657,6 @@ Free Text:SCT2\J:freetext
 Free Text:SCT2\J:freetext
 Free Text:SCT2\J:freetext
 Free Text:SCT2\J:freetext
-Free Text:SCT2\J:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
@@ -2448,6 +2667,11 @@ Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
 Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J1:freetext
+Free Text:SCT2\J2:freetext
+Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
 Free Text:SCT2\J2:freetext
@@ -2484,7 +2708,6 @@ Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
 Free Text:SCT2\K2:freetext
-Free Text:SCT2\K2:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
 Free Text:SCT2\K3:freetext
@@ -2494,9 +2717,6 @@ Free Text:SCT2\K4:freetext
 Free Text:SCT2\K4 Apron:freetext
 Free Text:SCT2\K5:freetext
 Free Text:SCT2\K5:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
-Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
 Free Text:SCT2\L:freetext
@@ -2596,7 +2816,6 @@ Free Text:SCT2\M1:freetext
 Free Text:SCT2\M1:freetext
 Free Text:SCT2\M1:freetext
 Free Text:SCT2\M1:freetext
-Free Text:SCT2\M1:freetext
 Free Text:SCT2\M2:freetext
 Free Text:SCT2\M2:freetext
 Free Text:SCT2\M2:freetext
@@ -2649,12 +2868,14 @@ Free Text:SCT2\NB3:freetext
 Free Text:SCT2\NB8:freetext
 Free Text:SCT2\NC1:freetext
 Free Text:SCT2\NC2:freetext
+Free Text:SCT2\NE:freetext
 Free Text:SCT2\NESSY:freetext
 Free Text:SCT2\NEVIS:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\North Apron:freetext
 Free Text:SCT2\NPAS:freetext
 Free Text:SCT2\NR:freetext
+Free Text:SCT2\NW:freetext
 Free Text:SCT2\OSTER:freetext
 Free Text:SCT2\P:freetext
 Free Text:SCT2\P:freetext
@@ -2667,22 +2888,17 @@ Free Text:SCT2\P3:freetext
 Free Text:SCT2\P3:freetext
 Free Text:SCT2\P4:freetext
 Free Text:SCT2\PLUTO:freetext
+Free Text:SCT2\Police Air Support:freetext
 Free Text:SCT2\PR:freetext
 Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q:freetext
-Free Text:SCT2\Q:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
 Free Text:SCT2\Q1:freetext
+Free Text:SCT2\Q2:freetext
 Free Text:SCT2\Q3:freetext
 Free Text:SCT2\QR:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
-Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
 Free Text:SCT2\R:freetext
@@ -2765,6 +2981,7 @@ Free Text:SCT2\RABIT:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
 Free Text:SCT2\S:freetext
+Free Text:SCT2\S:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
 Free Text:SCT2\S1:freetext
@@ -2790,6 +3007,7 @@ Free Text:SCT2\S7:freetext
 Free Text:SCT2\SAR:freetext
 Free Text:SCT2\SATUN:freetext
 Free Text:SCT2\SB3:freetext
+Free Text:SCT2\SE:freetext
 Free Text:SCT2\SNAPA:freetext
 Free Text:SCT2\South Apron:freetext
 Free Text:SCT2\South Apron:freetext
@@ -2799,6 +3017,8 @@ Free Text:SCT2\SQ5:freetext
 Free Text:SCT2\SY4:freetext
 Free Text:SCT2\SY5:freetext
 Free Text:SCT2\SY6:freetext
+Free Text:SCT2\T:freetext
+Free Text:SCT2\T:freetext
 Free Text:SCT2\T:freetext
 Free Text:SCT2\T:freetext
 Free Text:SCT2\T:freetext
@@ -2827,9 +3047,11 @@ Free Text:SCT2\T7:freetext
 Free Text:SCT2\T8:freetext
 Free Text:SCT2\T9:freetext
 Free Text:SCT2\Terminal:freetext
+Free Text:SCT2\TG:freetext
 Free Text:SCT2\TITAN:freetext
 Free Text:SCT2\Tower:freetext
 Free Text:SCT2\Tower Apron:freetext
+Free Text:SCT2\TP-D:freetext
 Free Text:SCT2\TP-L1:freetext
 Free Text:SCT2\TP-L2:freetext
 Free Text:SCT2\TP-L3:freetext
@@ -2843,6 +3065,8 @@ Free Text:SCT2\TP-X:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Y:freetext
 Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\TP-Z:freetext
+Free Text:SCT2\Triangle:freetext
 Free Text:SCT2\TULLA:freetext
 Free Text:SCT2\U:freetext
 Free Text:SCT2\U:freetext
@@ -2889,6 +3113,7 @@ Free Text:SCT2\VLP 1:freetext
 Free Text:SCT2\VLP 2:freetext
 Free Text:SCT2\VLP 3:freetext
 Free Text:SCT2\VN:freetext
+Free Text:SCT2\VOR Field:freetext
 Free Text:SCT2\VS:freetext
 Free Text:SCT2\W:freetext
 Free Text:SCT2\W:freetext
@@ -2938,6 +3163,7 @@ Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y1:freetext
+Free Text:SCT2\Y1:freetext
 Free Text:SCT2\Y2:freetext
 Free Text:SCT2\Y2:freetext
 Free Text:SCT2\Y2:freetext
@@ -2952,9 +3178,13 @@ Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z1:freetext
+Free Text:SCT2\Z1:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
 Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z2:freetext
+Free Text:SCT2\Z3:freetext
+Free Text:SCT2\Z4:freetext
 Geo:EGCC Manchester:
 Regions:Manchester:polygon
 SHOWC:1


### PR DESCRIPTION
Fixes #737

# Summary of changes

Adds Q2 & E10 holds to all displays that show EGCC ground layout

Also took the oppourtunity to display all SCT2 data on all SMR displays

# Screenshots (if necessary)

Nil
