### PR TITLE
CPDLC Auto open settings window

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2024/07 to 2024/08
+X. Enhancement - CPDLC Auto open settings window - thanks to @kye-taylor (Kye Taylor)
+
 # Changes from release 2024/06 to 2024/07
 1. AIRAC (2407) - Converted Brize Norton (EGVN) frequencies to 8.33kHz spacing - thanks to @danielbutton (Daniel Button)
 2. Procedure Change (2407) - Updated Cambridge (EGSC) and Ronaldsway (EGNS) frequencies - thanks to @PLM1995 (Peter Mooney)

--- a/UK/Data/Plugin/TopSky/TopSkySettings.txt
+++ b/UK/Data/Plugin/TopSky/TopSkySettings.txt
@@ -152,6 +152,7 @@ CPDLC_DCT=1
 CPDLC_AHDG=1
 CPDLC_ASP=1
 Window_CPDLC_Current=1,975,0
+Window_CPDLC_Setting=1
 
 //MSAW System Settings
 MSAW_Buffer_IFR=100

--- a/UK/Data/Plugin/TopSky_iTEC/TopSkySettings.txt
+++ b/UK/Data/Plugin/TopSky_iTEC/TopSkySettings.txt
@@ -207,6 +207,7 @@ CPDLC_DCT=1
 CPDLC_AHDG=1
 CPDLC_ASP=1
 Window_CPDLC_Current=1,975,0
+Window_CPDLC_Setting=1
 
 //MSAW System Settings
 MSAW_Buffer_IFR=100


### PR DESCRIPTION
Fixes #778 

# Summary of changes
Addition of this line two the TopSkySettings.txt in both instances
`Window_CPDLC_Setting=1`
