### PR TITLE
2408 pre release bugs - RMA displays

### DIFF
--- a/UK/Data/ASR/AC_S/Southend SMR.asr
+++ b/UK/Data/ASR/AC_S/Southend SMR.asr
@@ -3276,7 +3276,6 @@ Regions:Shobdon:polygon
 Regions:Shoreham:polygon
 Regions:Southampton:polygon
 Regions:Southend:polygon
-Regions:Southend RMA:polygon
 Regions:St Athan:polygon
 Regions:Stansted:polygon
 Regions:Stornoway:polygon

--- a/UK/Data/ASR/Belfast/Belfast Radar_1.asr
+++ b/UK/Data/ASR/Belfast/Belfast Radar_1.asr
@@ -369,7 +369,6 @@ ARTCC low boundary:LFRC Cherbourg CTR:
 ARTCC low boundary:LFRK Caen Carpiquet CTR:
 ARTCC low boundary:Solent CTA:
 Geo:Coastline (Medium Detail) GB Main Coastline:
-Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
 SHOWC:1
 SHOWSB:0

--- a/UK/Data/ASR/Belfast/Belfast Radar_1.asr
+++ b/UK/Data/ASR/Belfast/Belfast Radar_1.asr
@@ -371,10 +371,6 @@ ARTCC low boundary:Solent CTA:
 Geo:Coastline (Medium Detail) GB Main Coastline:
 Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 SHOWC:1
 SHOWSB:0
 BELOW:200

--- a/UK/Data/ASR/Belfast/Belfast Radar_2.asr
+++ b/UK/Data/ASR/Belfast/Belfast Radar_2.asr
@@ -1460,7 +1460,6 @@ Fixes:ZOFAT:symbol
 Fixes:ZOPHI:symbol
 Fixes:ZORFE:symbol
 Geo:Coastline (Medium Detail) GB Main Coastline:
-Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
 VORs:ABB:symbol
 VORs:ADN:symbol

--- a/UK/Data/ASR/Belfast/Belfast Radar_2.asr
+++ b/UK/Data/ASR/Belfast/Belfast Radar_2.asr
@@ -1462,9 +1462,6 @@ Fixes:ZORFE:symbol
 Geo:Coastline (Medium Detail) GB Main Coastline:
 Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Belfast/Belfast Radar_3.asr
+++ b/UK/Data/ASR/Belfast/Belfast Radar_3.asr
@@ -1836,7 +1836,6 @@ Free Text:Solent Airspace Bases\3000':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Geo:Coastline (Medium Detail) GB Main Coastline:
-Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
 VORs:ABB:symbol
 VORs:ADN:symbol

--- a/UK/Data/ASR/Belfast/Belfast Radar_3.asr
+++ b/UK/Data/ASR/Belfast/Belfast Radar_3.asr
@@ -1838,10 +1838,6 @@ Free Text:Solent Airspace Bases\3500':freetext
 Geo:Coastline (Medium Detail) GB Main Coastline:
 Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Belfast/Belfast Radar_4.asr
+++ b/UK/Data/ASR/Belfast/Belfast Radar_4.asr
@@ -3144,7 +3144,6 @@ Free Text:EGAC VRPs\*Groomsport:freetext
 Free Text:EGAC VRPs\*Saintfield:freetext
 Free Text:EGAC VRPs\*Whitehead:freetext
 Geo:Coastline (Medium Detail) GB Main Coastline:
-Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
 VORs:ABB:name
 VORs:ABB:symbol

--- a/UK/Data/ASR/Belfast/Belfast Radar_4.asr
+++ b/UK/Data/ASR/Belfast/Belfast Radar_4.asr
@@ -3146,10 +3146,6 @@ Free Text:EGAC VRPs\*Whitehead:freetext
 Geo:Coastline (Medium Detail) GB Main Coastline:
 Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/Channel Islands/Jersey Radar_4.asr
+++ b/UK/Data/ASR/Channel Islands/Jersey Radar_4.asr
@@ -2958,7 +2958,6 @@ Free Text:EGJJ VRPs\*Noirmont Point L'house:freetext
 Free Text:EGJJ VRPs\*Pointe de Rozel:freetext
 Free Text:EGJJ VRPs\*Roches Douvres L'house:freetext
 Free Text:EGJJ VRPs\*Seymour Tower:freetext
-Free Text:EGJJ VRPs\*St Germain:freetext
 Free Text:EGJJ VRPs\*St Martin's Point:freetext
 Geo:GEO:
 NDBs:ALD:frequency

--- a/UK/Data/ASR/Channel Islands/Jersey Radar_4.asr
+++ b/UK/Data/ASR/Channel Islands/Jersey Radar_4.asr
@@ -2958,6 +2958,7 @@ Free Text:EGJJ VRPs\*Noirmont Point L'house:freetext
 Free Text:EGJJ VRPs\*Pointe de Rozel:freetext
 Free Text:EGJJ VRPs\*Roches Douvres L'house:freetext
 Free Text:EGJJ VRPs\*Seymour Tower:freetext
+Free Text:EGJJ VRPs\*St Germain:freetext
 Free Text:EGJJ VRPs\*St Martin's Point:freetext
 Geo:GEO:
 NDBs:ALD:frequency

--- a/UK/Data/ASR/Edinburgh/Edinburgh Radar_1.asr
+++ b/UK/Data/ASR/Edinburgh/Edinburgh Radar_1.asr
@@ -394,7 +394,6 @@ Runways:EGPH Edinburgh 06-24:extended centerline 2 right vectoring
 Sids:EGPH Edinburgh Centerline:
 Sids:EGPH Edinburgh FAVA:
 Sids:EGPH Edinburgh SMAA:
-Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
 SHOWC:1
 SHOWSB:0

--- a/UK/Data/ASR/Edinburgh/Edinburgh Radar_1.asr
+++ b/UK/Data/ASR/Edinburgh/Edinburgh Radar_1.asr
@@ -396,10 +396,6 @@ Sids:EGPH Edinburgh FAVA:
 Sids:EGPH Edinburgh SMAA:
 Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 SHOWC:1
 SHOWSB:0
 BELOW:200

--- a/UK/Data/ASR/Edinburgh/Edinburgh Radar_2.asr
+++ b/UK/Data/ASR/Edinburgh/Edinburgh Radar_2.asr
@@ -1487,9 +1487,6 @@ Sids:EGPH Edinburgh FAVA:
 Sids:EGPH Edinburgh SMAA:
 Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Edinburgh/Edinburgh Radar_2.asr
+++ b/UK/Data/ASR/Edinburgh/Edinburgh Radar_2.asr
@@ -1485,7 +1485,6 @@ Runways:EGPH Edinburgh 06-24:extended centerline 2 right vectoring
 Sids:EGPH Edinburgh Centerline:
 Sids:EGPH Edinburgh FAVA:
 Sids:EGPH Edinburgh SMAA:
-Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
 VORs:ABB:symbol
 VORs:ADN:symbol

--- a/UK/Data/ASR/Edinburgh/Edinburgh Radar_3.asr
+++ b/UK/Data/ASR/Edinburgh/Edinburgh Radar_3.asr
@@ -1861,7 +1861,6 @@ Runways:EGPH Edinburgh 06-24:extended centerline 2 right vectoring
 Sids:EGPH Edinburgh Centerline:
 Sids:EGPH Edinburgh FAVA:
 Sids:EGPH Edinburgh SMAA:
-Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
 VORs:ABB:symbol
 VORs:ADN:symbol

--- a/UK/Data/ASR/Edinburgh/Edinburgh Radar_3.asr
+++ b/UK/Data/ASR/Edinburgh/Edinburgh Radar_3.asr
@@ -1863,10 +1863,6 @@ Sids:EGPH Edinburgh FAVA:
 Sids:EGPH Edinburgh SMAA:
 Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Edinburgh/Edinburgh Radar_4.asr
+++ b/UK/Data/ASR/Edinburgh/Edinburgh Radar_4.asr
@@ -3175,7 +3175,6 @@ Runways:EGPH Edinburgh 06-24:extended centerline 2 right vectoring
 Sids:EGPH Edinburgh Centerline:
 Sids:EGPH Edinburgh FAVA:
 Sids:EGPH Edinburgh SMAA:
-Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
 VORs:ABB:name
 VORs:ABB:symbol

--- a/UK/Data/ASR/Edinburgh/Edinburgh Radar_4.asr
+++ b/UK/Data/ASR/Edinburgh/Edinburgh Radar_4.asr
@@ -3177,10 +3177,6 @@ Sids:EGPH Edinburgh FAVA:
 Sids:EGPH Edinburgh SMAA:
 Stars:Edinburgh Local Area:
 Stars:Edinburgh-Glasgow Buffer:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/Essex/Combined Radar_1.asr
+++ b/UK/Data/ASR/Essex/Combined Radar_1.asr
@@ -320,9 +320,7 @@ ARTCC low boundary:LFRC Cherbourg CTR:
 ARTCC low boundary:LFRK Caen Carpiquet CTR:
 ARTCC low boundary:Solent CTA:
 Stars:Luton Noise Sensitive Areas:
-Stars:Luton RMA:
 Stars:Stansted Noise Sensitive Areas:
-Stars:Stansted RMA:
 Stars:X-Y Line:
 SHOWC:1
 SHOWSB:0

--- a/UK/Data/ASR/Essex/Combined Radar_2.asr
+++ b/UK/Data/ASR/Essex/Combined Radar_2.asr
@@ -1411,9 +1411,7 @@ Fixes:ZOFAT:symbol
 Fixes:ZOPHI:symbol
 Fixes:ZORFE:symbol
 Stars:Luton Noise Sensitive Areas:
-Stars:Luton RMA:
 Stars:Stansted Noise Sensitive Areas:
-Stars:Stansted RMA:
 Stars:X-Y Line:
 VORs:ABB:symbol
 VORs:ADN:symbol

--- a/UK/Data/ASR/Essex/Combined Radar_3.asr
+++ b/UK/Data/ASR/Essex/Combined Radar_3.asr
@@ -1838,9 +1838,7 @@ Free Text:Solent Airspace Bases\3000':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Stars:Luton Noise Sensitive Areas:
-Stars:Luton RMA:
 Stars:Stansted Noise Sensitive Areas:
-Stars:Stansted RMA:
 Stars:X-Y Line:
 VORs:ABB:symbol
 VORs:ADN:symbol

--- a/UK/Data/ASR/Essex/Combined Radar_4.asr
+++ b/UK/Data/ASR/Essex/Combined Radar_4.asr
@@ -3157,9 +3157,7 @@ Free Text:EGSS VRPs\*Puckeridge A10/A120:freetext
 Free Text:EGSS VRPs\*Spriggs Solar Farm:freetext
 Free Text:EGSS VRPs\*Ware:freetext
 Stars:Luton Noise Sensitive Areas:
-Stars:Luton RMA:
 Stars:Stansted Noise Sensitive Areas:
-Stars:Stansted RMA:
 Stars:X-Y Line:
 VORs:ABB:name
 VORs:ABB:symbol

--- a/UK/Data/ASR/Essex/Luton Radar_1.asr
+++ b/UK/Data/ASR/Essex/Luton Radar_1.asr
@@ -318,7 +318,6 @@ ARTCC low boundary:LFRC Cherbourg CTR:
 ARTCC low boundary:LFRK Caen Carpiquet CTR:
 ARTCC low boundary:Solent CTA:
 Stars:Luton Noise Sensitive Areas:
-Stars:Luton RMA:
 Stars:Luton-Stansted Buffer:
 SHOWC:1
 SHOWSB:0

--- a/UK/Data/ASR/Essex/Luton Radar_2.asr
+++ b/UK/Data/ASR/Essex/Luton Radar_2.asr
@@ -1409,7 +1409,6 @@ Fixes:ZOFAT:symbol
 Fixes:ZOPHI:symbol
 Fixes:ZORFE:symbol
 Stars:Luton Noise Sensitive Areas:
-Stars:Luton RMA:
 Stars:Luton-Stansted Buffer:
 VORs:ABB:symbol
 VORs:ADN:symbol

--- a/UK/Data/ASR/Essex/Luton Radar_3.asr
+++ b/UK/Data/ASR/Essex/Luton Radar_3.asr
@@ -1836,7 +1836,6 @@ Free Text:Solent Airspace Bases\3000':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Stars:Luton Noise Sensitive Areas:
-Stars:Luton RMA:
 Stars:Luton-Stansted Buffer:
 VORs:ABB:symbol
 VORs:ADN:symbol

--- a/UK/Data/ASR/Essex/Luton Radar_4.asr
+++ b/UK/Data/ASR/Essex/Luton Radar_4.asr
@@ -3140,7 +3140,6 @@ Free Text:EGGW VRPs\*M1 J9:freetext
 Free Text:EGGW VRPs\*Offley:freetext
 Free Text:EGGW VRPs\*Pirton:freetext
 Stars:Luton Noise Sensitive Areas:
-Stars:Luton RMA:
 Stars:Luton-Stansted Buffer:
 VORs:ABB:name
 VORs:ABB:symbol

--- a/UK/Data/ASR/Essex/Stansted Radar_1.asr
+++ b/UK/Data/ASR/Essex/Stansted Radar_1.asr
@@ -320,7 +320,6 @@ ARTCC low boundary:LFRK Caen Carpiquet CTR:
 ARTCC low boundary:Solent CTA:
 Stars:Luton-Stansted Buffer:
 Stars:Stansted Noise Sensitive Areas:
-Stars:Stansted RMA:
 Stars:X-Y Line:
 SHOWC:1
 SHOWSB:0

--- a/UK/Data/ASR/Essex/Stansted Radar_2.asr
+++ b/UK/Data/ASR/Essex/Stansted Radar_2.asr
@@ -1411,7 +1411,6 @@ Fixes:ZOPHI:symbol
 Fixes:ZORFE:symbol
 Stars:Luton-Stansted Buffer:
 Stars:Stansted Noise Sensitive Areas:
-Stars:Stansted RMA:
 Stars:X-Y Line:
 VORs:ABB:symbol
 VORs:ADN:symbol

--- a/UK/Data/ASR/Essex/Stansted Radar_3.asr
+++ b/UK/Data/ASR/Essex/Stansted Radar_3.asr
@@ -1838,7 +1838,6 @@ Free Text:Solent Airspace Bases\3500':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Stars:Luton-Stansted Buffer:
 Stars:Stansted Noise Sensitive Areas:
-Stars:Stansted RMA:
 Stars:X-Y Line:
 VORs:ABB:symbol
 VORs:ADN:symbol

--- a/UK/Data/ASR/Essex/Stansted Radar_4.asr
+++ b/UK/Data/ASR/Essex/Stansted Radar_4.asr
@@ -3157,7 +3157,6 @@ Free Text:EGSS VRPs\*Spriggs Solar Farm:freetext
 Free Text:EGSS VRPs\*Ware:freetext
 Stars:Luton-Stansted Buffer:
 Stars:Stansted Noise Sensitive Areas:
-Stars:Stansted RMA:
 Stars:X-Y Line:
 VORs:ABB:name
 VORs:ABB:symbol

--- a/UK/Data/ASR/FID/FID.asr
+++ b/UK/Data/ASR/FID/FID.asr
@@ -1666,6 +1666,7 @@ SIMULATION_MODE:1
 DISABLEPANNING:0
 DISABLEZOOMING:0
 DisplayRotation:0.00000
+TAGFAMILY:Flight Information Display
 WINDOWAREA:47.749467:-16.745920:57.992037:14.166342
 PLUGIN:UK Controller Plugin:approachSequencerContentCollapsed:0
 PLUGIN:UK Controller Plugin:approachSequencerVisible:0

--- a/UK/Data/ASR/FID/FID.asr
+++ b/UK/Data/ASR/FID/FID.asr
@@ -1666,7 +1666,6 @@ SIMULATION_MODE:1
 DISABLEPANNING:0
 DISABLEZOOMING:0
 DisplayRotation:0.00000
-TAGFAMILY:Flight Information Display
 WINDOWAREA:47.749467:-16.745920:57.992037:14.166342
 PLUGIN:UK Controller Plugin:approachSequencerContentCollapsed:0
 PLUGIN:UK Controller Plugin:approachSequencerVisible:0

--- a/UK/Data/ASR/Gatwick/Gatwick Radar_1.asr
+++ b/UK/Data/ASR/Gatwick/Gatwick Radar_1.asr
@@ -330,7 +330,6 @@ ARTCC low boundary:LFRC Cherbourg CTR:
 ARTCC low boundary:LFRG Deauville CTR:
 ARTCC low boundary:LFRK Caen Carpiquet CTR:
 ARTCC low boundary:Solent CTA:
-Stars:Gatwick RMA Westerlies:
 SHOWC:1
 SHOWSB:0
 BELOW:200

--- a/UK/Data/ASR/Gatwick/Gatwick Radar_2.asr
+++ b/UK/Data/ASR/Gatwick/Gatwick Radar_2.asr
@@ -1421,7 +1421,6 @@ Fixes:ZIPWE:symbol
 Fixes:ZOFAT:symbol
 Fixes:ZOPHI:symbol
 Fixes:ZORFE:symbol
-Stars:Gatwick RMA Westerlies:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Gatwick/Gatwick Radar_3.asr
+++ b/UK/Data/ASR/Gatwick/Gatwick Radar_3.asr
@@ -1856,7 +1856,6 @@ Free Text:Solent Airspace Bases\2500':freetext
 Free Text:Solent Airspace Bases\3000':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Free Text:Solent Airspace Bases\3500':freetext
-Stars:Gatwick RMA Westerlies:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Gatwick/Gatwick Radar_4.asr
+++ b/UK/Data/ASR/Gatwick/Gatwick Radar_4.asr
@@ -3156,7 +3156,6 @@ Free Text:EGKR VRPs\*A25 (Godstone Jct):freetext
 Free Text:EGKR VRPs\*Buckland:freetext
 Free Text:EGKR VRPs\*Godstone Rail Stn:freetext
 Free Text:EGKR VRPs\*J7 M25/J8 M23:freetext
-Stars:Gatwick RMA Westerlies:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_1.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_1.asr
@@ -433,7 +433,6 @@ PLUGIN:UK Controller Plugin:holdFOYLEMinimised:1
 PLUGIN:UK Controller Plugin:holdFOYLEMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFOYLEPositionX:0
 PLUGIN:UK Controller Plugin:holdFOYLEPositionY:24
-PLUGIN:UK Controller Plugin:holdFYNERMaxLevel:14000
 PLUGIN:UK Controller Plugin:holdFYNERMinimised:1
 PLUGIN:UK Controller Plugin:holdFYNERMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFYNERPositionX:225

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_1.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_1.asr
@@ -383,7 +383,6 @@ Sids:EGPF Glasgow SMAA:
 Stars:Edinburgh-Glasgow Buffer:
 Stars:Glasgow Campsie Line:
 Stars:Glasgow Designated Area:
-Stars:Glasgow Local Area:
 Stars:Glasgow Talla Boundary:
 Stars:Glasgow Tay Boundary:
 Stars:Glasgow TMA Boundary:

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_1.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_1.asr
@@ -432,6 +432,7 @@ PLUGIN:UK Controller Plugin:holdFOYLEMinimised:1
 PLUGIN:UK Controller Plugin:holdFOYLEMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFOYLEPositionX:0
 PLUGIN:UK Controller Plugin:holdFOYLEPositionY:24
+PLUGIN:UK Controller Plugin:holdFYNERMaxLevel:14000
 PLUGIN:UK Controller Plugin:holdFYNERMinimised:1
 PLUGIN:UK Controller Plugin:holdFYNERMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFYNERPositionX:225

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_2.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_2.asr
@@ -1618,6 +1618,7 @@ PLUGIN:UK Controller Plugin:holdFOYLEMinimised:1
 PLUGIN:UK Controller Plugin:holdFOYLEMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFOYLEPositionX:0
 PLUGIN:UK Controller Plugin:holdFOYLEPositionY:24
+PLUGIN:UK Controller Plugin:holdFYNERMaxLevel:14000
 PLUGIN:UK Controller Plugin:holdFYNERMinimised:1
 PLUGIN:UK Controller Plugin:holdFYNERMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFYNERPositionX:225

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_2.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_2.asr
@@ -1619,7 +1619,6 @@ PLUGIN:UK Controller Plugin:holdFOYLEMinimised:1
 PLUGIN:UK Controller Plugin:holdFOYLEMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFOYLEPositionX:0
 PLUGIN:UK Controller Plugin:holdFOYLEPositionY:24
-PLUGIN:UK Controller Plugin:holdFYNERMaxLevel:14000
 PLUGIN:UK Controller Plugin:holdFYNERMinimised:1
 PLUGIN:UK Controller Plugin:holdFYNERMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFYNERPositionX:225

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_2.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_2.asr
@@ -1474,7 +1474,6 @@ Sids:EGPF Glasgow SMAA:
 Stars:Edinburgh-Glasgow Buffer:
 Stars:Glasgow Campsie Line:
 Stars:Glasgow Designated Area:
-Stars:Glasgow Local Area:
 Stars:Glasgow Talla Boundary:
 Stars:Glasgow Tay Boundary:
 Stars:Glasgow TMA Boundary:

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_3.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_3.asr
@@ -1850,7 +1850,6 @@ Sids:EGPF Glasgow SMAA:
 Stars:Edinburgh-Glasgow Buffer:
 Stars:Glasgow Campsie Line:
 Stars:Glasgow Designated Area:
-Stars:Glasgow Local Area:
 Stars:Glasgow Talla Boundary:
 Stars:Glasgow Tay Boundary:
 Stars:Glasgow TMA Boundary:

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_3.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_3.asr
@@ -1994,6 +1994,7 @@ PLUGIN:UK Controller Plugin:holdFOYLEMinimised:1
 PLUGIN:UK Controller Plugin:holdFOYLEMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFOYLEPositionX:0
 PLUGIN:UK Controller Plugin:holdFOYLEPositionY:24
+PLUGIN:UK Controller Plugin:holdFYNERMaxLevel:14000
 PLUGIN:UK Controller Plugin:holdFYNERMinimised:1
 PLUGIN:UK Controller Plugin:holdFYNERMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFYNERPositionX:225

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_3.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_3.asr
@@ -1995,7 +1995,6 @@ PLUGIN:UK Controller Plugin:holdFOYLEMinimised:1
 PLUGIN:UK Controller Plugin:holdFOYLEMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFOYLEPositionX:0
 PLUGIN:UK Controller Plugin:holdFOYLEPositionY:24
-PLUGIN:UK Controller Plugin:holdFYNERMaxLevel:14000
 PLUGIN:UK Controller Plugin:holdFYNERMinimised:1
 PLUGIN:UK Controller Plugin:holdFYNERMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFYNERPositionX:225

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_4.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_4.asr
@@ -3160,7 +3160,6 @@ Sids:EGPF Glasgow SMAA:
 Stars:Edinburgh-Glasgow Buffer:
 Stars:Glasgow Campsie Line:
 Stars:Glasgow Designated Area:
-Stars:Glasgow Local Area:
 Stars:Glasgow Talla Boundary:
 Stars:Glasgow Tay Boundary:
 Stars:Glasgow TMA Boundary:

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_4.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_4.asr
@@ -3164,7 +3164,6 @@ Stars:Glasgow Local Area:
 Stars:Glasgow Talla Boundary:
 Stars:Glasgow Tay Boundary:
 Stars:Glasgow TMA Boundary:
-Stars:Heathrow RMA Westerlies:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name
@@ -3401,7 +3400,6 @@ PLUGIN:UK Controller Plugin:holdFOYLEMinimised:1
 PLUGIN:UK Controller Plugin:holdFOYLEMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFOYLEPositionX:0
 PLUGIN:UK Controller Plugin:holdFOYLEPositionY:24
-PLUGIN:UK Controller Plugin:holdFYNERMaxLevel:14000
 PLUGIN:UK Controller Plugin:holdFYNERMinimised:1
 PLUGIN:UK Controller Plugin:holdFYNERMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFYNERPositionX:225

--- a/UK/Data/ASR/Glasgow/Glasgow Radar_4.asr
+++ b/UK/Data/ASR/Glasgow/Glasgow Radar_4.asr
@@ -3399,6 +3399,7 @@ PLUGIN:UK Controller Plugin:holdFOYLEMinimised:1
 PLUGIN:UK Controller Plugin:holdFOYLEMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFOYLEPositionX:0
 PLUGIN:UK Controller Plugin:holdFOYLEPositionY:24
+PLUGIN:UK Controller Plugin:holdFYNERMaxLevel:14000
 PLUGIN:UK Controller Plugin:holdFYNERMinimised:1
 PLUGIN:UK Controller Plugin:holdFYNERMinLevel:7000
 PLUGIN:UK Controller Plugin:holdFYNERPositionX:225

--- a/UK/Data/ASR/Heathrow/Heathrow Radar_1.asr
+++ b/UK/Data/ASR/Heathrow/Heathrow Radar_1.asr
@@ -324,7 +324,6 @@ ARTCC low boundary:LFRC Cherbourg CTR:
 ARTCC low boundary:LFRG Deauville CTR:
 ARTCC low boundary:LFRK Caen Carpiquet CTR:
 ARTCC low boundary:Solent CTA:
-Stars:Heathrow RMA (Realistic):
 VORs:BIG:symbol
 VORs:BNN:symbol
 VORs:LAM:symbol

--- a/UK/Data/ASR/Heathrow/Heathrow Radar_2.asr
+++ b/UK/Data/ASR/Heathrow/Heathrow Radar_2.asr
@@ -1418,7 +1418,6 @@ Fixes:ZIPWE:symbol
 Fixes:ZOFAT:symbol
 Fixes:ZOPHI:symbol
 Fixes:ZORFE:symbol
-Stars:Heathrow RMA (Realistic):
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Heathrow/Heathrow Radar_3.asr
+++ b/UK/Data/ASR/Heathrow/Heathrow Radar_3.asr
@@ -1848,7 +1848,6 @@ Free Text:Solent Airspace Bases\2500':freetext
 Free Text:Solent Airspace Bases\3000':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Free Text:Solent Airspace Bases\3500':freetext
-Stars:Heathrow RMA Westerlies:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Heathrow/Heathrow Radar_4.asr
+++ b/UK/Data/ASR/Heathrow/Heathrow Radar_4.asr
@@ -2992,7 +2992,6 @@ Low airways:H7:line
 Low airways:H7:name
 Low airways:H9:line
 Low airways:H9:name
-Stars:Heathrow RMA Westerlies:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/LTC/TCE4.asr
+++ b/UK/Data/ASR/LTC/TCE4.asr
@@ -3135,10 +3135,6 @@ Fixes:ZOPHI:name
 Fixes:ZOPHI:symbol
 Fixes:ZORFE:name
 Fixes:ZORFE:symbol
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/LTC/TCS4.asr
+++ b/UK/Data/ASR/LTC/TCS4.asr
@@ -3148,11 +3148,6 @@ Fixes:ZOPHI:symbol
 Fixes:ZORFE:name
 Fixes:ZORFE:symbol
 Regions:Uncontrolled airspace:polygon
-Stars:Gatwick RMA Westerlies:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/Liverpool/Liverpool ATM.asr
+++ b/UK/Data/ASR/Liverpool/Liverpool ATM.asr
@@ -750,7 +750,6 @@ Runways:EGGP Liverpool 09-27:extended centerline 2 left vectoring
 Runways:EGGP Liverpool 09-27:extended centerline 2 right base
 Runways:EGGP Liverpool 09-27:extended centerline 2 right ticks
 Runways:EGGP Liverpool 09-27:extended centerline 2 right vectoring
-Stars:Manchester RMA Westerlies:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/Liverpool/Liverpool Radar_1.asr
+++ b/UK/Data/ASR/Liverpool/Liverpool Radar_1.asr
@@ -368,8 +368,6 @@ Runways:EIDW Dublin 10L-28R:centerline
 Runways:EIDW Dublin 10R-28L:centerline
 Runways:EIDW Dublin 16-34:centerline
 Sids:EGGP Liverpool SMAA:
-Stars:Hawarden RMA:
-Stars:Liverpool RMA:
 SHOWC:1
 SHOWSB:0
 BELOW:200

--- a/UK/Data/ASR/Liverpool/Liverpool Radar_2.asr
+++ b/UK/Data/ASR/Liverpool/Liverpool Radar_2.asr
@@ -1459,8 +1459,6 @@ Runways:EIDW Dublin 10L-28R:centerline
 Runways:EIDW Dublin 10R-28L:centerline
 Runways:EIDW Dublin 16-34:centerline
 Sids:EGGP Liverpool SMAA:
-Stars:Hawarden RMA:
-Stars:Liverpool RMA:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Liverpool/Liverpool Radar_3.asr
+++ b/UK/Data/ASR/Liverpool/Liverpool Radar_3.asr
@@ -1835,8 +1835,6 @@ Runways:EIDW Dublin 10L-28R:centerline
 Runways:EIDW Dublin 10R-28L:centerline
 Runways:EIDW Dublin 16-34:centerline
 Sids:EGGP Liverpool SMAA:
-Stars:Hawarden RMA:
-Stars:Liverpool RMA:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Liverpool/Liverpool Radar_4.asr
+++ b/UK/Data/ASR/Liverpool/Liverpool Radar_4.asr
@@ -3153,8 +3153,6 @@ Runways:EIDW Dublin 10L-28R:centerline
 Runways:EIDW Dublin 10R-28L:centerline
 Runways:EIDW Dublin 16-34:centerline
 Sids:EGGP Liverpool SMAA:
-Stars:Hawarden RMA:
-Stars:Liverpool RMA:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/MPC/PC1.asr
+++ b/UK/Data/ASR/MPC/PC1.asr
@@ -329,7 +329,6 @@ Stars:DEXEN Buffer:
 Stars:HON Gate:
 Stars:Leeds Bradford Gates:
 Stars:Leeds Delegation Line:
-Stars:Manchester RMA Westerlies:
 Stars:POL - LBA Line:
 Stars:RAMOX Buffer Area A:
 Stars:RAMOX Buffer Area B:

--- a/UK/Data/ASR/MPC/PC2.asr
+++ b/UK/Data/ASR/MPC/PC2.asr
@@ -1420,7 +1420,6 @@ Stars:DEXEN Buffer:
 Stars:HON Gate:
 Stars:Leeds Bradford Gates:
 Stars:Leeds Delegation Line:
-Stars:Manchester RMA Westerlies:
 Stars:POL - LBA Line:
 Stars:RAMOX Buffer Area A:
 Stars:RAMOX Buffer Area B:

--- a/UK/Data/ASR/MPC/PC3.asr
+++ b/UK/Data/ASR/MPC/PC3.asr
@@ -1857,7 +1857,6 @@ Stars:DEXEN Buffer:
 Stars:HON Gate:
 Stars:Leeds Bradford Gates:
 Stars:Leeds Delegation Line:
-Stars:Manchester RMA Westerlies:
 Stars:POL - LBA Line:
 Stars:RAMOX Buffer Area A:
 Stars:RAMOX Buffer Area B:

--- a/UK/Data/ASR/MPC/PC4.asr
+++ b/UK/Data/ASR/MPC/PC4.asr
@@ -3137,13 +3137,8 @@ Fixes:ZOPHI:symbol
 Fixes:ZORFE:name
 Fixes:ZORFE:symbol
 Geo:Coastline (Medium Detail) GB Main Coastline:
-Stars:Heathrow RMA Westerlies:
 Stars:Leeds Bradford Gates:
 Stars:Leeds Delegation Line:
-Stars:Luton RMA:
-Stars:Manchester RMA Westerlies:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/Manchester/Manchester ATM.asr
+++ b/UK/Data/ASR/Manchester/Manchester ATM.asr
@@ -757,7 +757,6 @@ Runways:EGCC Manchester 05R-23L:extended centerline 2 left vectoring
 Runways:EGCC Manchester 05R-23L:extended centerline 2 right base
 Runways:EGCC Manchester 05R-23L:extended centerline 2 right ticks
 Runways:EGCC Manchester 05R-23L:extended centerline 2 right vectoring
-Stars:Manchester RMA Westerlies:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/Manchester/Manchester Radar_1.asr
+++ b/UK/Data/ASR/Manchester/Manchester Radar_1.asr
@@ -387,7 +387,6 @@ Regions:A-Scottish:polygon
 Regions:A-SouthWalesMidlands:polygon
 Sids:EGCC Manchester FAVA:
 Sids:EGCC Manchester SMAA:
-Stars:Manchester RMA Westerlies:
 SHOWC:1
 SHOWSB:0
 BELOW:200

--- a/UK/Data/ASR/Manchester/Manchester Radar_2.asr
+++ b/UK/Data/ASR/Manchester/Manchester Radar_2.asr
@@ -1478,7 +1478,6 @@ Regions:A-Scottish:polygon
 Regions:A-SouthWalesMidlands:polygon
 Sids:EGCC Manchester FAVA:
 Sids:EGCC Manchester SMAA:
-Stars:Manchester RMA Westerlies:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Manchester/Manchester Radar_3.asr
+++ b/UK/Data/ASR/Manchester/Manchester Radar_3.asr
@@ -1857,7 +1857,6 @@ Regions:A-Scottish:polygon
 Regions:A-SouthWalesMidlands:polygon
 Sids:EGCC Manchester FAVA:
 Sids:EGCC Manchester SMAA:
-Stars:Manchester RMA Westerlies:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Manchester/Manchester Radar_4.asr
+++ b/UK/Data/ASR/Manchester/Manchester Radar_4.asr
@@ -3177,7 +3177,6 @@ Regions:A-Scottish:polygon
 Regions:A-SouthWalesMidlands:polygon
 Sids:EGCC Manchester FAVA:
 Sids:EGCC Manchester SMAA:
-Stars:Manchester RMA Westerlies:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/Military/Mil APC.asr
+++ b/UK/Data/ASR/Military/Mil APC.asr
@@ -924,14 +924,8 @@ Stars:AARA 9:
 Stars:Altimeter Setting Regions:
 Stars:Bristol Delegated Area:
 Stars:Cardiff Delegated Area:
-Stars:Gatwick RMA Westerlies:
 Stars:Heathrow Inner CTA:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Northolt RMA:
-Stars:Stansted RMA:
 Stars:Thames RAVSA Rings:
-Stars:Thames RMA:
 SHOWC:1
 SHOWSB:0
 BELOW:200

--- a/UK/Data/ASR/Military/Swanwick.asr
+++ b/UK/Data/ASR/Military/Swanwick.asr
@@ -686,14 +686,8 @@ Stars:AARA 9:
 Stars:Altimeter Setting Regions:
 Stars:Bristol Delegated Area:
 Stars:Cardiff Delegated Area:
-Stars:Gatwick RMA Westerlies:
 Stars:Heathrow Inner CTA:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Northolt RMA:
-Stars:Stansted RMA:
 Stars:Thames RAVSA Rings:
-Stars:Thames RMA:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AFI:symbol

--- a/UK/Data/ASR/PX_AC/AC1N.asr
+++ b/UK/Data/ASR/PX_AC/AC1N.asr
@@ -55,9 +55,6 @@ Sids:Scottish AC South:
 Sids:Scottish Deancross:
 Sids:Scottish Rathlin:
 Sids:Scottish West:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 SHOWC:1
 SHOWSB:0
 BELOW:200

--- a/UK/Data/ASR/PX_AC/AC1T.asr
+++ b/UK/Data/ASR/PX_AC/AC1T.asr
@@ -56,9 +56,6 @@ Sids:Scottish AC South:
 Sids:Scottish Deancross:
 Sids:Scottish Rathlin:
 Sids:Scottish West:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 SHOWC:1
 SHOWSB:0
 BELOW:200

--- a/UK/Data/ASR/Route Checker.asr
+++ b/UK/Data/ASR/Route Checker.asr
@@ -341,7 +341,6 @@ SIMULATION_MODE:1
 DISABLEPANNING:0
 DISABLEZOOMING:0
 DisplayRotation:0.00000
-TAGFAMILY:Flight Information Display
 WINDOWAREA:48.803171:-23.855087:61.025516:14.785232
 PLUGIN:UK Controller Plugin:approachSequencerContentCollapsed:0
 PLUGIN:UK Controller Plugin:approachSequencerVisible:0

--- a/UK/Data/ASR/Route Checker.asr
+++ b/UK/Data/ASR/Route Checker.asr
@@ -341,6 +341,7 @@ SIMULATION_MODE:1
 DISABLEPANNING:0
 DISABLEZOOMING:0
 DisplayRotation:0.00000
+TAGFAMILY:Flight Information Display
 WINDOWAREA:48.803171:-23.855087:61.025516:14.785232
 PLUGIN:UK Controller Plugin:approachSequencerContentCollapsed:0
 PLUGIN:UK Controller Plugin:approachSequencerVisible:0

--- a/UK/Data/ASR/Southend/Southend Radar_1.asr
+++ b/UK/Data/ASR/Southend/Southend Radar_1.asr
@@ -442,6 +442,7 @@ PLUGIN:UK Controller Plugin:holdGEGMUMinimised:0
 PLUGIN:UK Controller Plugin:holdGEGMUMinLevel:4000
 PLUGIN:UK Controller Plugin:holdGEGMUPositionX:1436
 PLUGIN:UK Controller Plugin:holdGEGMUPositionY:826
+PLUGIN:UK Controller Plugin:holdSPEARMaxLevel:7000
 PLUGIN:UK Controller Plugin:holdSPEARMinimised:0
 PLUGIN:UK Controller Plugin:holdSPEARMinLevel:4000
 PLUGIN:UK Controller Plugin:holdSPEARPositionX:153

--- a/UK/Data/ASR/Southend/Southend Radar_1.asr
+++ b/UK/Data/ASR/Southend/Southend Radar_1.asr
@@ -394,7 +394,6 @@ ARTCC low boundary:LFRG Deauville CTR:
 ARTCC low boundary:LFRK Caen Carpiquet CTR:
 ARTCC low boundary:Solent CTA:
 Geo:Coastline (Medium Detail) GB Main Coastline:
-Regions:Southend RMA:polygon
 Stars:EKNIV Gate:
 Stars:Thames-Southend Buffer:
 SHOWC:1
@@ -443,7 +442,6 @@ PLUGIN:UK Controller Plugin:holdGEGMUMinimised:0
 PLUGIN:UK Controller Plugin:holdGEGMUMinLevel:4000
 PLUGIN:UK Controller Plugin:holdGEGMUPositionX:1436
 PLUGIN:UK Controller Plugin:holdGEGMUPositionY:826
-PLUGIN:UK Controller Plugin:holdSPEARMaxLevel:7000
 PLUGIN:UK Controller Plugin:holdSPEARMinimised:0
 PLUGIN:UK Controller Plugin:holdSPEARMinLevel:4000
 PLUGIN:UK Controller Plugin:holdSPEARPositionX:153

--- a/UK/Data/ASR/Southend/Southend Radar_2.asr
+++ b/UK/Data/ASR/Southend/Southend Radar_2.asr
@@ -410,7 +410,6 @@ Fixes:RAVSA:symbol
 Fixes:SABER:name
 Fixes:SABER:symbol
 Geo:Coastline (Medium Detail) GB Main Coastline:
-Regions:Southend RMA:polygon
 Stars:EKNIV Gate:
 Stars:Thames-Southend Buffer:
 VORs:ABB:name
@@ -687,7 +686,6 @@ PLUGIN:UK Controller Plugin:holdGEGMUMinimised:0
 PLUGIN:UK Controller Plugin:holdGEGMUMinLevel:4000
 PLUGIN:UK Controller Plugin:holdGEGMUPositionX:1436
 PLUGIN:UK Controller Plugin:holdGEGMUPositionY:826
-PLUGIN:UK Controller Plugin:holdSPEARMaxLevel:7000
 PLUGIN:UK Controller Plugin:holdSPEARMinimised:0
 PLUGIN:UK Controller Plugin:holdSPEARMinLevel:4000
 PLUGIN:UK Controller Plugin:holdSPEARPositionX:153

--- a/UK/Data/ASR/Southend/Southend Radar_2.asr
+++ b/UK/Data/ASR/Southend/Southend Radar_2.asr
@@ -686,6 +686,7 @@ PLUGIN:UK Controller Plugin:holdGEGMUMinimised:0
 PLUGIN:UK Controller Plugin:holdGEGMUMinLevel:4000
 PLUGIN:UK Controller Plugin:holdGEGMUPositionX:1436
 PLUGIN:UK Controller Plugin:holdGEGMUPositionY:826
+PLUGIN:UK Controller Plugin:holdSPEARMaxLevel:7000
 PLUGIN:UK Controller Plugin:holdSPEARMinimised:0
 PLUGIN:UK Controller Plugin:holdSPEARMinLevel:4000
 PLUGIN:UK Controller Plugin:holdSPEARPositionX:153

--- a/UK/Data/ASR/Southend/Southend Radar_3.asr
+++ b/UK/Data/ASR/Southend/Southend Radar_3.asr
@@ -786,7 +786,6 @@ Free Text:Solent Airspace Bases\3000':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Geo:Coastline (Medium Detail) GB Main Coastline:
-Regions:Southend RMA:polygon
 Stars:EKNIV Gate:
 Stars:Thames-Southend Buffer:
 VORs:ABB:name
@@ -1063,7 +1062,6 @@ PLUGIN:UK Controller Plugin:holdGEGMUMinimised:0
 PLUGIN:UK Controller Plugin:holdGEGMUMinLevel:4000
 PLUGIN:UK Controller Plugin:holdGEGMUPositionX:1436
 PLUGIN:UK Controller Plugin:holdGEGMUPositionY:826
-PLUGIN:UK Controller Plugin:holdSPEARMaxLevel:7000
 PLUGIN:UK Controller Plugin:holdSPEARMinimised:0
 PLUGIN:UK Controller Plugin:holdSPEARMinLevel:4000
 PLUGIN:UK Controller Plugin:holdSPEARPositionX:153

--- a/UK/Data/ASR/Southend/Southend Radar_3.asr
+++ b/UK/Data/ASR/Southend/Southend Radar_3.asr
@@ -1062,6 +1062,7 @@ PLUGIN:UK Controller Plugin:holdGEGMUMinimised:0
 PLUGIN:UK Controller Plugin:holdGEGMUMinLevel:4000
 PLUGIN:UK Controller Plugin:holdGEGMUPositionX:1436
 PLUGIN:UK Controller Plugin:holdGEGMUPositionY:826
+PLUGIN:UK Controller Plugin:holdSPEARMaxLevel:7000
 PLUGIN:UK Controller Plugin:holdSPEARMinimised:0
 PLUGIN:UK Controller Plugin:holdSPEARMinLevel:4000
 PLUGIN:UK Controller Plugin:holdSPEARPositionX:153

--- a/UK/Data/ASR/Southend/Southend Radar_4.asr
+++ b/UK/Data/ASR/Southend/Southend Radar_4.asr
@@ -3217,7 +3217,6 @@ Free Text:EGMC VRPs\*Southend Pier:freetext
 Free Text:EGMC VRPs\*Southminster:freetext
 Free Text:EGMC VRPs\*Whitstable Harbour:freetext
 Geo:Coastline (Medium Detail) GB Main Coastline:
-Regions:Southend RMA:polygon
 Stars:EKNIV Gate:
 Stars:Thames-Southend Buffer:
 VORs:ABB:name

--- a/UK/Data/ASR/Southend/Southend SMR.asr
+++ b/UK/Data/ASR/Southend/Southend SMR.asr
@@ -3276,7 +3276,6 @@ Regions:Shobdon:polygon
 Regions:Shoreham:polygon
 Regions:Southampton:polygon
 Regions:Southend:polygon
-Regions:Southend RMA:polygon
 Regions:St Athan:polygon
 Regions:Stansted:polygon
 Regions:Stornoway:polygon

--- a/UK/Data/ASR/TC_APP/Generic Radar_1.asr
+++ b/UK/Data/ASR/TC_APP/Generic Radar_1.asr
@@ -151,10 +151,6 @@ ARTCC low boundary:LFOH Le Havre CTR:
 ARTCC low boundary:LFRC Cherbourg CTR:
 ARTCC low boundary:LFRK Caen Carpiquet CTR:
 ARTCC low boundary:Solent CTA:
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 SHOWC:1
 SHOWSB:0
 BELOW:200

--- a/UK/Data/ASR/TC_APP/Generic Radar_2.asr
+++ b/UK/Data/ASR/TC_APP/Generic Radar_2.asr
@@ -1242,10 +1242,6 @@ Fixes:ZIPWE:symbol
 Fixes:ZOFAT:symbol
 Fixes:ZOPHI:symbol
 Fixes:ZORFE:symbol
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/TC_APP/Generic Radar_3.asr
+++ b/UK/Data/ASR/TC_APP/Generic Radar_3.asr
@@ -1625,7 +1625,6 @@ Free Text:Solent Airspace Bases\2500':freetext
 Free Text:Solent Airspace Bases\3000':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Free Text:Solent Airspace Bases\3500':freetext
-Stars:Heathrow RMA Westerlies:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/TC_APP/Generic Radar_4.asr
+++ b/UK/Data/ASR/TC_APP/Generic Radar_4.asr
@@ -2915,10 +2915,6 @@ Fixes:ZOPHI:name
 Fixes:ZOPHI:symbol
 Fixes:ZORFE:name
 Fixes:ZORFE:symbol
-Stars:Heathrow RMA Westerlies:
-Stars:Luton RMA:
-Stars:Stansted RMA:
-Stars:Thames RMA:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name

--- a/UK/Data/ASR/Thames/Southend SMR.asr
+++ b/UK/Data/ASR/Thames/Southend SMR.asr
@@ -3276,7 +3276,6 @@ Regions:Shobdon:polygon
 Regions:Shoreham:polygon
 Regions:Southampton:polygon
 Regions:Southend:polygon
-Regions:Southend RMA:polygon
 Regions:St Athan:polygon
 Regions:Stansted:polygon
 Regions:Stornoway:polygon

--- a/UK/Data/ASR/Thames/Thames Radar_1.asr
+++ b/UK/Data/ASR/Thames/Thames Radar_1.asr
@@ -318,7 +318,6 @@ ARTCC low boundary:LFRK Caen Carpiquet CTR:
 ARTCC low boundary:Solent CTA:
 Geo:EGLC City Transitions:
 Stars:Thames RAVSA Rings:
-Stars:Thames RMA:
 SHOWC:1
 SHOWSB:0
 BELOW:200

--- a/UK/Data/ASR/Thames/Thames Radar_2.asr
+++ b/UK/Data/ASR/Thames/Thames Radar_2.asr
@@ -1409,7 +1409,6 @@ Fixes:ZOPHI:symbol
 Fixes:ZORFE:symbol
 Geo:EGLC City Transitions:
 Stars:Thames RAVSA Rings:
-Stars:Thames RMA:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Thames/Thames Radar_3.asr
+++ b/UK/Data/ASR/Thames/Thames Radar_3.asr
@@ -1616,7 +1616,6 @@ Free Text:Solent Airspace Bases\3500':freetext
 Free Text:Solent Airspace Bases\3500':freetext
 Geo:EGLC City Transitions:
 Stars:Thames RAVSA Rings:
-Stars:Thames RMA:
 VORs:ABB:symbol
 VORs:ADN:symbol
 VORs:AMB:symbol

--- a/UK/Data/ASR/Thames/Thames Radar_4.asr
+++ b/UK/Data/ASR/Thames/Thames Radar_4.asr
@@ -3221,7 +3221,6 @@ Low airways:H7:name
 Low airways:H9:line
 Low airways:H9:name
 Stars:Thames RAVSA Rings:
-Stars:Thames RMA:
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name


### PR DESCRIPTION
# Summary of changes

Display of RMAs now controlled by TopSky, remove default RMAs from display settings.

# Screenshots (if necessary)

Nil.
