### PR TITLE
Fixes #864 - Manchester (EGCC) ATM Extended Centrelines Display

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2024/09 to 2024/10
+1. Manchester (EGCC) ATm Extended Centreline Display Fixed - thanks to @luke11brown (Luke Brown)
+
 # Changes from release 2024/08 to 2024/09
 1. AIRAC (2409) - Connington (EGSF) Radio Frequency Updated - thanks to @kristiankunc (Kristián Kunc)
 2. Bug - Added vFPC to Heathrow (EGLL) SMR and ATM lists - thanks to @kristiankunc (Kristián Kunc)

--- a/UK/Data/ASR/Manchester/Manchester ATM.asr
+++ b/UK/Data/ASR/Manchester/Manchester ATM.asr
@@ -737,26 +737,12 @@ NDBs:YVL:name
 NDBs:YVL:symbol
 Regions:Coastline:polygon
 Runways:EGCC Manchester 05L-23R:extended centerline 1
-Runways:EGCC Manchester 05L-23R:extended centerline 1 left base
 Runways:EGCC Manchester 05L-23R:extended centerline 1 left ticks
-Runways:EGCC Manchester 05L-23R:extended centerline 1 left vectoring
-Runways:EGCC Manchester 05L-23R:extended centerline 1 right base
-Runways:EGCC Manchester 05L-23R:extended centerline 1 right ticks
-Runways:EGCC Manchester 05L-23R:extended centerline 1 right vectoring
 Runways:EGCC Manchester 05L-23R:extended centerline 2
-Runways:EGCC Manchester 05L-23R:extended centerline 2 left base
 Runways:EGCC Manchester 05L-23R:extended centerline 2 left ticks
-Runways:EGCC Manchester 05L-23R:extended centerline 2 left vectoring
-Runways:EGCC Manchester 05L-23R:extended centerline 2 right base
 Runways:EGCC Manchester 05L-23R:extended centerline 2 right ticks
-Runways:EGCC Manchester 05L-23R:extended centerline 2 right vectoring
-Runways:EGCC Manchester 05R-23L:extended centerline 2
-Runways:EGCC Manchester 05R-23L:extended centerline 2 left base
-Runways:EGCC Manchester 05R-23L:extended centerline 2 left ticks
-Runways:EGCC Manchester 05R-23L:extended centerline 2 left vectoring
-Runways:EGCC Manchester 05R-23L:extended centerline 2 right base
-Runways:EGCC Manchester 05R-23L:extended centerline 2 right ticks
-Runways:EGCC Manchester 05R-23L:extended centerline 2 right vectoring
+Runways:EGCC Manchester 05R-23L:extended centerline 1
+Runways:EGCC Manchester 05R-23L:extended centerline 1 right ticks
 VORs:ABB:name
 VORs:ABB:symbol
 VORs:ADN:name


### PR DESCRIPTION
Fixes #864 

# Summary of changes
Corrects display of EGCC extended centrelines on the ATM profile.

# Screenshots (if necessary)

Landing 05R
![image](https://github.com/user-attachments/assets/635cebe3-5829-4e75-857f-8fee0e72288e)

Landing 05L
![image](https://github.com/user-attachments/assets/0ef476f7-2cc7-4587-bf7e-420d4dd54e8a)

Landing 23R
![image](https://github.com/user-attachments/assets/ebd67655-ef40-4c19-92af-ef61d6059135)

