### PR TITLE
Fixes #881 - Exclude Non-UK sector file profiles from AIRAC auto update

### DIFF
--- a/UK/Military/Akrotiri.prf
+++ b/UK/Military/Akrotiri.prf
@@ -1,4 +1,4 @@
-Settings	sector	UK\Data\Sector\UK_2024_10.sct
+Settings	sector	UK\Data\Sector\Akrotiri LCRA.sct
 Settings	SettingsfilePLUGINS	\..\Data\Settings\Local\Akrotiri\Plugins.txt
 Settings	SettingsfilePROFILE	\..\Data\Settings\Local\Akrotiri\Profiles.txt
 Settings	SettingsfileSCREEN	\..\Data\Settings\Screen.txt

--- a/workflows/airac/auto_airac_actions.py
+++ b/workflows/airac/auto_airac_actions.py
@@ -280,7 +280,7 @@ class CurrentInstallation:
             chk = False
             for line in lines:
                 # Add the sector file path
-                content = re.sub(r"^Settings\tsector\t(.*)", sf_replace, line)
+                content = re.sub(r"^Settings\tsector\t.*UK.+", sf_replace, line)
                 chk = True
 
                 # Write the updated content back to the file


### PR DESCRIPTION
Fixes #881 

# Summary of changes

Profiles that don't use UK sector file are excluded from auto airac update

# Screenshots (if necessary)

Nil
