### PR TITLE
Fixes #919 - Ignore non-"UK" sector files in AIRAC workflow

### DIFF
--- a/workflows/airac/auto_airac_actions.py
+++ b/workflows/airac/auto_airac_actions.py
@@ -256,7 +256,7 @@ class CurrentInstallation:
             chk = False
             for line in lines:
                 # Add the sector file path
-                content = re.sub(r"^Settings\tsector\t.*UK.+", sf_replace, line)
+                content = re.sub(r"^Settings\tsector\t.*\\UK.+", sf_replace, line)
                 chk = True
 
                 # Write the updated content back to the file


### PR DESCRIPTION
Fixes #919

# Summary of changes

My mistake last time, sorry :sweat_smile: have tested the regex properly now; should match only paths including `\UK`