### PR TITLE
Fixes #857 - Add SRD search dialog to FPL column in startup lists

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changes from release 2024/13 to 2025/01
-x. Enhancement - Added SRD search dialog to taxi out list - thanks to @kristiankunc (Kristián Kunc)
+x. Enhancement - Added SRD search dialog to startup lists - thanks to @kristiankunc (Kristián Kunc)
 
 # Changes from release 2024/12 to 2024/13
 1. Bug - Fixed Farnborough Radar trails and tags - thanks to @SamLefevre (Samuel Lefevre)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2024/13 to 2025/01
+x. Enhancement - Added SRD search dialog to taxi out list - thanks to @kristiankunc (Kristián Kunc)
+
 # Changes from release 2024/12 to 2024/13
 1. Bug - Fixed Farnborough Radar trails and tags - thanks to @SamLefevre (Samuel Lefevre)
 2. Enhancement - Added QSY column to combined departure lists - thanks to @kristiankunc (Kristián Kunc)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changes from release 2024/13 to 2025/01
-x. Enhancement - Added SRD search dialog to startup lists - thanks to @kristiankunc (Kristián Kunc)
+1. Enhancement - Added SRD search dialog to startup lists - thanks to @kristiankunc (Kristián Kunc)
 
 # Changes from release 2024/12 to 2024/13
 1. Bug - Fixed Farnborough Radar trails and tags - thanks to @SamLefevre (Samuel Lefevre)

--- a/UK/Data/Settings/Lists.txt
+++ b/UK/Data/Settings/Lists.txt
@@ -169,7 +169,7 @@ m_Column:A/C:8:1:105:7:7:1:UK Controller Plugin:::3:0.0
 m_Column:Stand:5:1:110:9007:9008:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:0:0.0
 m_Column:SPad:8:1:19:29:29:1::::4:0.0
 m_Column:FPL:4:1:1:100:9004:0:VFPC (UK):VFPC (UK):UK Controller Plugin:0:0.0
-m_Column:R:2:1:63:7:7:1::::3:0.0
+m_Column:R:2:1:63:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:RFL:4:1:22:30:30:1::::3:0.0
 m_Column:ADES:4:1:17:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:SID:7:0:56:17:17:1::::4:0.0

--- a/UK/Data/Settings/Lists_Area.txt
+++ b/UK/Data/Settings/Lists_Area.txt
@@ -157,7 +157,7 @@ m_Column:A/C:8:1:105:7:7:1:UK Controller Plugin:::3:0.0
 m_Column:Stand:5:1:110:9007:9008:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:0:0.0
 m_Column:SPad:8:1:19:29:29:1::::4:0.0
 m_Column:FPL:4:1:1:100:9004:0:VFPC (UK):VFPC (UK):UK Controller Plugin:0:0.0
-m_Column:R:2:1:63:7:7:1::::3:0.0
+m_Column:R:2:1:63:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:RFL:4:1:22:30:30:1::::3:0.0
 m_Column:ADES:4:1:17:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:SID:7:0:56:17:17:1::::4:0.0

--- a/UK/Data/Settings/Lists_SMR.txt
+++ b/UK/Data/Settings/Lists_SMR.txt
@@ -168,7 +168,7 @@ m_Column:A/C:8:1:105:7:7:1:UK Controller Plugin:::3:0.0
 m_Column:Stand:5:1:110:9007:9008:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:0:0.0
 m_Column:SPad:8:1:19:29:29:1::::4:0.0
 m_Column:FPL:4:1:1:100:9004:0:VFPC (UK):VFPC (UK):UK Controller Plugin:0:0.0
-m_Column:R:2:1:63:7:9004:1:::UK Controller Plugin:3:0.0
+m_Column:R:2:1:63:7:7:1::::3:0.0
 m_Column:RFL:4:1:22:30:30:1::::3:0.0
 m_Column:ADES:4:1:17:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:SID:7:0:56:17:17:1::::4:0.0
@@ -237,4 +237,20 @@ m_Column:RLS:3:1:124:9012:9015:1:UK Controller Plugin:UK Controller Plugin:UK Co
 m_Column::6:0:125:9014:9014:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column:PRE:3:1:127:9017:9018:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column:QSY:7:0:107:0:0:1:UK Controller Plugin:::1:0.0
+END
+TAXIIN
+m_Visible:0
+m_X:120
+m_Y:100
+m_LineNumber:6
+m_Resizable:0
+m_OrderingColumn:1
+m_HeaderOnly:0
+m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
+m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
+m_Column:RQT:3:1:544:548:0:0:VCH:VCH::0:0.0
+m_Column:CALLSIGN:9:0:9:8:0:1::::0:0.0
+m_Column:STN:4:1:19:29:0:1::::1:0.0
+m_Column:ATYP:4:1:16:0:0:1::::1:0.0
+m_Column:STS:4:1:59:46:28:1::::1:0.0
 END

--- a/UK/Data/Settings/Lists_SMR.txt
+++ b/UK/Data/Settings/Lists_SMR.txt
@@ -168,7 +168,7 @@ m_Column:A/C:8:1:105:7:7:1:UK Controller Plugin:::3:0.0
 m_Column:Stand:5:1:110:9007:9008:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:0:0.0
 m_Column:SPad:8:1:19:29:29:1::::4:0.0
 m_Column:FPL:4:1:1:100:9004:0:VFPC (UK):VFPC (UK):UK Controller Plugin:0:0.0
-m_Column:R:2:1:63:7:7:1::::3:0.0
+m_Column:R:2:1:63:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:RFL:4:1:22:30:30:1::::3:0.0
 m_Column:ADES:4:1:17:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:SID:7:0:56:17:17:1::::4:0.0
@@ -237,20 +237,4 @@ m_Column:RLS:3:1:124:9012:9015:1:UK Controller Plugin:UK Controller Plugin:UK Co
 m_Column::6:0:125:9014:9014:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column:PRE:3:1:127:9017:9018:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column:QSY:7:0:107:0:0:1:UK Controller Plugin:::1:0.0
-END
-TAXIIN
-m_Visible:0
-m_X:120
-m_Y:100
-m_LineNumber:6
-m_Resizable:0
-m_OrderingColumn:1
-m_HeaderOnly:0
-m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
-m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
-m_Column:RQT:3:1:544:548:0:0:VCH:VCH::0:0.0
-m_Column:CALLSIGN:9:0:9:8:0:1::::0:0.0
-m_Column:STN:4:1:19:29:0:1::::1:0.0
-m_Column:ATYP:4:1:16:0:0:1::::1:0.0
-m_Column:STS:4:1:59:46:28:1::::1:0.0
 END

--- a/UK/Data/Settings/Lists_SMR.txt
+++ b/UK/Data/Settings/Lists_SMR.txt
@@ -168,7 +168,7 @@ m_Column:A/C:8:1:105:7:7:1:UK Controller Plugin:::3:0.0
 m_Column:Stand:5:1:110:9007:9008:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:0:0.0
 m_Column:SPad:8:1:19:29:29:1::::4:0.0
 m_Column:FPL:4:1:1:100:9004:0:VFPC (UK):VFPC (UK):UK Controller Plugin:0:0.0
-m_Column:R:2:1:63:7:7:1::::3:0.0
+m_Column:R:2:1:63:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:RFL:4:1:22:30:30:1::::3:0.0
 m_Column:ADES:4:1:17:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:SID:7:0:56:17:17:1::::4:0.0

--- a/UK/Data/Settings/Lists_TopSky.txt
+++ b/UK/Data/Settings/Lists_TopSky.txt
@@ -157,7 +157,7 @@ m_Column:A/C:8:1:105:7:7:1:UK Controller Plugin:::3:0.0
 m_Column:Stand:5:1:110:9007:9008:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:0:0.0
 m_Column:SPad:8:1:19:29:29:1::::4:0.0
 m_Column:FPL:4:1:1:100:9004:0:VFPC (UK):VFPC (UK):UK Controller Plugin:0:0.0
-m_Column:R:2:1:63:7:7:1::::3:0.0
+m_Column:R:2:1:63:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:RFL:4:1:22:30:30:1::::3:0.0
 m_Column:ADES:4:1:17:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:SID:7:0:56:17:17:1::::4:0.0


### PR DESCRIPTION
Fixes #857

# Summary of changes

Right clicking the flight plan column will now open SRD search instead of the flight plan (which is opened by left click)

*apologies for the delay, completely forgot I picked up this issue*