### PR TITLE
Fixes #944 - Add Jersey (EGJJ) settings to NOVA TopSky

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2024/13 to 2025/01
+1. Bug - Added Jersey settings to TopSky NOVA - thanks to @SamLefevre (Samuel Lefevre)
+
 # Changes from release 2024/12 to 2024/13
 1. Bug - Fixed Farnborough Radar trails and tags - thanks to @SamLefevre (Samuel Lefevre)
 2. Enhancement - Added QSY column to combined departure lists - thanks to @kristiankunc (Kristián Kunc)

--- a/UK/Data/Plugin/TopSky_NOVA/TopSkySettings.txt
+++ b/UK/Data/Plugin/TopSky_NOVA/TopSkySettings.txt
@@ -535,3 +535,48 @@ Color_Active_Map_Type_4=154,100,150
 Color_Active_Map_Type_5=192,192,192
 //VRPs
 Color_Active_Map_Type_9=192,192,192
+
+[EGJA_]
+Setup_ScreenLat=EGJA
+//Colour settings
+//Danger area (red)
+Color_Active_Map_Type_1=198,115,113
+Color_Active_Text_Map=198,115,113
+//ARTCC High (Grey on NERC)
+Color_Active_Map_Type_2=185,214,219
+//Freetext
+Color_Active_Map_Type_3=255,255,255
+//STARs (RMA Lines)
+Color_Active_Map_Type_4=143,143,143
+//Centrelines
+Color_Active_Map_Type_5=255,255,255
+
+[EGJB_]
+Setup_ScreenLat=EGJB
+//Colour settings
+//Danger area (red)
+Color_Active_Map_Type_1=198,115,113
+Color_Active_Text_Map=198,115,113
+//ARTCC High (Grey on NERC)
+Color_Active_Map_Type_2=185,214,219
+//Freetext
+Color_Active_Map_Type_3=255,255,255
+//STARs (RMA Lines)
+Color_Active_Map_Type_4=143,143,143
+//Centrelines
+Color_Active_Map_Type_5=255,255,255
+
+[EGJJ_]
+Setup_ScreenLat=EGJJ
+//Colour settings
+//Danger area (red)
+Color_Active_Map_Type_1=198,115,113
+Color_Active_Text_Map=198,115,113
+//ARTCC High (Grey on NERC)
+Color_Active_Map_Type_2=185,214,219
+//Freetext
+Color_Active_Map_Type_3=255,255,255
+//STARs (RMA Lines)
+Color_Active_Map_Type_4=143,143,143
+//Centrelines
+Color_Active_Map_Type_5=255,255,255


### PR DESCRIPTION
Fixes #944 

# Summary of changes

Added settings to NOVA TopSky

# Screenshots (if necessary)

![EuroScope_cqIT5vSNd1](https://github.com/user-attachments/assets/d3f334c6-86ee-410e-af2a-1f0ef69c79fe)
