### PR TITLE
Fixes #1005 - Enable ASEL Highlighting on ATM Lists

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,6 +3,7 @@
 2. AIRAC (2503) - London Gatwick (EGKK) RECAT-EU Implementation - thanks to @luke11brown (Luke Brown)
 3. Enhancement - Updated CDM Plugin to 2.2.5.3 - thanks to @luke11brown (Luke Brown)
 4. Bug & Enhancement - Fixed various TopSky settings and added centreline shortcut (ALT+T) - thanks to @SamLefevre (Samuel Lefevre)
+5. Enhancement - Enabled ASEL Highlighting on ATM Lists - thanks to @PLM1995 (Peter Mooney)
 
 # Changes from release 2025/01 to 2025/02
 1. Enhancement - Added Ronaldsway (EGNS) settings and displays - thanks to @SamLefevre (Samuel Lefevre)

--- a/UK/Data/Settings/ATM/ATM_General.txt
+++ b/UK/Data/Settings/ATM/ATM_General.txt
@@ -62,7 +62,7 @@ SET_WTC_A380:J
 m_RotateRouteTexts:1
 m_NeverCloseFreqChat:1
 m_KeepScratchPadAfterDirect:0
-m_HiliteASELAircraft:0
+m_HiliteASELAircraft:1
 m_EnableVoiceRecognition:0
 m_VoiceRecognitionStyle:2
 m_SModeTransponders:IEFGRWQ

--- a/UK/Data/Settings/ATM/ATM_General_5A.txt
+++ b/UK/Data/Settings/ATM/ATM_General_5A.txt
@@ -62,7 +62,7 @@ SET_WTC_A380:J
 m_RotateRouteTexts:1
 m_NeverCloseFreqChat:1
 m_KeepScratchPadAfterDirect:0
-m_HiliteASELAircraft:0
+m_HiliteASELAircraft:1
 m_EnableVoiceRecognition:0
 m_VoiceRecognitionStyle:2
 m_SModeTransponders:IEFGRWQ

--- a/UK/Data/Settings/Local/Essex/GW_ATM_General.txt
+++ b/UK/Data/Settings/Local/Essex/GW_ATM_General.txt
@@ -62,7 +62,7 @@ SET_WTC_A380:J
 m_RotateRouteTexts:1
 m_NeverCloseFreqChat:1
 m_KeepScratchPadAfterDirect:0
-m_HiliteASELAircraft:0
+m_HiliteASELAircraft:1
 m_EnableVoiceRecognition:0
 m_VoiceRecognitionStyle:2
 m_SModeTransponders:IEFGRWQ

--- a/UK/Data/Settings/Local/Essex/SS_ATM_General.txt
+++ b/UK/Data/Settings/Local/Essex/SS_ATM_General.txt
@@ -62,7 +62,7 @@ SET_WTC_A380:J
 m_RotateRouteTexts:1
 m_NeverCloseFreqChat:1
 m_KeepScratchPadAfterDirect:0
-m_HiliteASELAircraft:0
+m_HiliteASELAircraft:1
 m_EnableVoiceRecognition:0
 m_VoiceRecognitionStyle:2
 m_SModeTransponders:IEFGRWQ

--- a/UK/Data/Settings/Local/Heathrow/ATM_LL_General.txt
+++ b/UK/Data/Settings/Local/Heathrow/ATM_LL_General.txt
@@ -62,7 +62,7 @@ SET_WTC_A380:J
 m_RotateRouteTexts:1
 m_NeverCloseFreqChat:1
 m_KeepScratchPadAfterDirect:0
-m_HiliteASELAircraft:0
+m_HiliteASELAircraft:1
 m_EnableVoiceRecognition:0
 m_VoiceRecognitionStyle:2
 m_SModeTransponders:IEFGRWQ


### PR DESCRIPTION
Fixes #1005

# Summary of changes

Changed in all 5 instances to enable ASEL highlighting on ATM profile lists.
