### PR TITLE
Fixes #994 - Remove Puckeridge VRP from Gatwick profile

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,6 +3,7 @@
 2. AIRAC (2503) - London Gatwick (EGKK) RECAT-EU Implementation - thanks to @luke11brown (Luke Brown)
 3. Enhancement - Updated CDM Plugin to 2.2.5.3 - thanks to @luke11brown (Luke Brown)
 4. Bug & Enhancement - Fixed various TopSky settings and added centreline shortcut (ALT+T) - thanks to @SamLefevre (Samuel Lefevre)
+x. Bug - Remove Puckeridge VRP from Gatwick profile - thanks to @AdriTheDev (Callum Hicks)
 
 # Changes from release 2025/01 to 2025/02
 1. Enhancement - Added Ronaldsway (EGNS) settings and displays - thanks to @SamLefevre (Samuel Lefevre)

--- a/UK/Data/ASR/Gatwick/Gatwick Radar_4.asr
+++ b/UK/Data/ASR/Gatwick/Gatwick Radar_4.asr
@@ -3151,7 +3151,6 @@ Free Text:EGKK VRPs\*Dorking:freetext
 Free Text:EGKK VRPs\*Guildford Rail Stn:freetext
 Free Text:EGKK VRPs\*Handcross:freetext
 Free Text:EGKK VRPs\*Haywards Heath:freetext
-Free Text:EGKK VRPs\*Puckeridge A10/A120:freetext
 Free Text:EGKK VRPs\*Tunbridge Wells:freetext
 Free Text:EGKR VRPs\*A25 (Godstone Jct):freetext
 Free Text:EGKR VRPs\*Buckland:freetext
@@ -3361,7 +3360,8 @@ DISABLEZOOMING:0
 DisplayRotation:0.00000
 TAGFAMILY:NODE
 WINDOWAREA:50.184318:-2.603270:51.841227:2.634963
-PLUGIN:TopSky plugin:HideMapData:NERC,AirspaceBases,Fixes,FixLabelsPLUGIN:UK Controller Plugin:approachSequencerContentCollapsed:0
+PLUGIN:TopSky plugin:HideMapData:NERC,AirspaceBases,Fixes,FixLabels
+PLUGIN:UK Controller Plugin:approachSequencerContentCollapsed:0
 PLUGIN:UK Controller Plugin:approachSequencerVisible:0
 PLUGIN:UK Controller Plugin:approachSequencerXPosition:200
 PLUGIN:UK Controller Plugin:approachSequencerYPosition:200


### PR DESCRIPTION
Fixes #994 

# Summary of changes

Removed Puckeridge VRP from Gatwick profiles.

# Screenshots (if necessary)

N/A
