### PR TITLE
Fixes #1041 - TopSky TSA Pre-active Time Threshold

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 6. Enhancement - Displayed LFP81 (Prohibited Area up to FL195 - nuclear site) on AC Area ASRs - thanks to @hazzas-99
 7. Enhancement - General AC Area ASR display setting updates - thanks to @hazzas-99
 8. Bug - Corrected Manchester (EGCC) Planner frequency - thanks to @PLM1995 (Peter Mooney)
+9. Enhancement - Changed TopSky pre-active time to 30 minutes - thanks to @Liaely (Lily Unitt)
 
 # Changes from release 2025/02 to 2025/03
 1. AIRAC (2503) - Modified EAMTA Lateral Confines - thanks to @quassbutreally

--- a/UK/Data/Plugin/TopSky_NERC/TopSkySettings.txt
+++ b/UK/Data/Plugin/TopSky_NERC/TopSkySettings.txt
@@ -29,6 +29,7 @@ Airspace_ASSR_Type=0
 Areas_NOTAM_Activation=1
 Areas_Label_Font=Arial
 Areas_Label_FontSize=9
+Areas_PreActiveTime=1800
 Track_HistoryDots=0
 System_MagModel_Type=2
 System_MagModel_Model=0

--- a/UK/Data/Plugin/TopSky_NODE/TopSkySettings.txt
+++ b/UK/Data/Plugin/TopSky_NODE/TopSkySettings.txt
@@ -29,6 +29,7 @@ Airspace_ASSR_Type=0
 Areas_NOTAM_Activation=1
 Areas_Label_Font=Arial
 Areas_Label_FontSize=9
+Areas_PreActiveTime=1800
 Track_HistoryDots=0
 System_MagModel_Type=2
 System_MagModel_Model=0

--- a/UK/Data/Plugin/TopSky_NOVA/TopSkySettings.txt
+++ b/UK/Data/Plugin/TopSky_NOVA/TopSkySettings.txt
@@ -29,6 +29,7 @@ Airspace_ASSR_Type=0
 Areas_NOTAM_Activation=1
 Areas_Label_Font=Arial
 Areas_Label_FontSize=9
+Areas_PreActiveTime=1800
 Track_HistoryDots=0
 System_MagModel_Type=2
 System_MagModel_Model=0

--- a/UK/Data/Plugin/TopSky_iTEC/TopSkySettings.txt
+++ b/UK/Data/Plugin/TopSky_iTEC/TopSkySettings.txt
@@ -29,6 +29,7 @@ Airspace_ASSR_Type=0
 Areas_NOTAM_Activation=1
 Areas_Label_Font=Arial
 Areas_Label_FontSize=9
+Areas_PreActiveTime=1800
 Track_HistoryDots=0
 System_MagModel_Type=2
 System_MagModel_Model=0


### PR DESCRIPTION
Fixes #1041 

# Summary of changes

Add line `Areas_PreActiveTime=1800` to the TopSky settings for all 4 systems to set pre-active time to 30 minutes (up from 10 minutes).