### PR TITLE
Fixes #1047 - Add CDM to combined profiles

### DIFF
--- a/UK/Aberdeen/Aberdeen.prf
+++ b/UK/Aberdeen/Aberdeen.prf
@@ -34,6 +34,7 @@ Plugins	Plugin2	\..\Data\Plugin\AfvEuroScopeBridge.dll
 Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt

--- a/UK/Belfast/Belfast.prf
+++ b/UK/Belfast/Belfast.prf
@@ -37,6 +37,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Birmingham/Birmingham.prf
+++ b/UK/Birmingham/Birmingham.prf
@@ -35,6 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Bristol/Bristol.prf
+++ b/UK/Bristol/Bristol.prf
@@ -35,6 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Cardiff/Cardiff.prf
+++ b/UK/Cardiff/Cardiff.prf
@@ -37,6 +37,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Channel Islands/Jersey.prf
+++ b/UK/Channel Islands/Jersey.prf
@@ -34,6 +34,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Data/Settings/Lists.txt
+++ b/UK/Data/Settings/Lists.txt
@@ -72,11 +72,15 @@ m_Column:STS:4:1:59:46:28:1::::4:0.0
 m_Column:C/S:8:0:9:0:1:1::::3:0.0
 m_Column:RT:2:0:80:32:0:1::::4:0.0
 m_Column:EVT:3:0:5000:0:0:0:VATCAN Bookings:::4:0.0
-m_Column:TOBT:5:1:2:6:3:0:vACDM:vACDM:vACDM:0:0.0
-m_Column:TSAT:5:1:3:8:9:0:vACDM:vACDM:vACDM:0:0.0
-m_Column:ASRT:5:1:3:8:9:0:vACDM:vACDM:vACDM:0:0.0
-m_Column:ASAT:5:1:6:14:14:0:vACDM:vACDM:vACDM:0:0.0
-m_Column:TTOT:5:1:4:1:0:0:vACDM:vACDM::0:0.0
+m_Column:EOBT:5:1:1:117:100:0:CDM Plugin:CDM Plugin:CDM Plugin:4:0.0
+m_Column:TOBT:5:1:4:114:121:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:TSAT:5:1:2:133:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:ASAT:5:1:6:123:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:ASRT:5:1:7:107:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:TTOT:5:1:3:128:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:CTOT:5:1:10:108:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:EVNT:5:1:15:129:130:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:NET:5:1:18:137:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
 m_Column:CTOT:5:1:5001:0:0:0:VATCAN Bookings:::0:0.0
 m_Column:GS:3:1:40:0:0:0::::3:0.0
 m_Column:ADEP:4:1:61:9004:0:1::UK Controller Plugin::3:0.0

--- a/UK/Data/Settings/Lists_RECAT.txt
+++ b/UK/Data/Settings/Lists_RECAT.txt
@@ -62,6 +62,15 @@ m_Resizable:1
 m_OrderingColumn:1
 m_HeaderOnly:0
 m_Column:EVT:3:0:5000:0:0:0:VATCAN Bookings:::4:0.0
+m_Column:EOBT:5:1:1:117:100:0:CDM Plugin:CDM Plugin:CDM Plugin:4:0.0
+m_Column:TOBT:5:1:4:114:121:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:TSAT:5:1:2:133:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:ASAT:5:1:6:123:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:ASRT:5:1:7:107:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:TTOT:5:1:3:128:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:CTOT:5:1:10:108:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:EVNT:5:1:15:129:130:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
+m_Column:NET:5:1:18:137:123:0:CDM Plugin:CDM Plugin:CDM Plugin:0:0.0
 m_Column:CTOT:5:0:5001:0:0:0:VATCAN Bookings:::1:0.0
 m_Column:AOBT:5:1:103:0:0:0:UK Controller Plugin:::3:0.0
 m_Column:EDT:5:0:102:0:0:0:UK Controller Plugin:::3:0.0

--- a/UK/East Midlands/East Midlands.prf
+++ b/UK/East Midlands/East Midlands.prf
@@ -35,7 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/East Midlands/East Midlands.prf
+++ b/UK/East Midlands/East Midlands.prf
@@ -35,6 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Edinburgh/Edinburgh.prf
+++ b/UK/Edinburgh/Edinburgh.prf
@@ -35,6 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Edinburgh/Edinburgh.prf
+++ b/UK/Edinburgh/Edinburgh.prf
@@ -35,7 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Essex/Essex.prf
+++ b/UK/Essex/Essex.prf
@@ -40,6 +40,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
+Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Essex/Essex.prf
+++ b/UK/Essex/Essex.prf
@@ -40,7 +40,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
-Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin7	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Essex/Luton.prf
+++ b/UK/Essex/Luton.prf
@@ -36,6 +36,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
+Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Essex/Luton.prf
+++ b/UK/Essex/Luton.prf
@@ -36,7 +36,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
-Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin7	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Essex/Stansted.prf
+++ b/UK/Essex/Stansted.prf
@@ -38,7 +38,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
-Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin7	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Essex/Stansted.prf
+++ b/UK/Essex/Stansted.prf
@@ -38,6 +38,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
+Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Exeter/Exeter.prf
+++ b/UK/Exeter/Exeter.prf
@@ -35,6 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Exeter/Exeter.prf
+++ b/UK/Exeter/Exeter.prf
@@ -35,7 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Farnborough/Farnborough.prf
+++ b/UK/Farnborough/Farnborough.prf
@@ -63,6 +63,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 ASRFastKeys	1	\..\Data\ASR\Farnborough\Farnborough Radar_1.asr
 ASRFastKeys	2	\..\Data\ASR\Farnborough\Farnborough Radar_2.asr
 ASRFastKeys	3	\..\Data\ASR\Farnborough\Farnborough Radar_3.asr

--- a/UK/Farnborough/Farnborough.prf
+++ b/UK/Farnborough/Farnborough.prf
@@ -63,7 +63,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 ASRFastKeys	1	\..\Data\ASR\Farnborough\Farnborough Radar_1.asr
 ASRFastKeys	2	\..\Data\ASR\Farnborough\Farnborough Radar_2.asr
 ASRFastKeys	3	\..\Data\ASR\Farnborough\Farnborough Radar_3.asr

--- a/UK/Gatwick/Gatwick.prf
+++ b/UK/Gatwick/Gatwick.prf
@@ -38,7 +38,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
-Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin7	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Gatwick/Gatwick.prf
+++ b/UK/Gatwick/Gatwick.prf
@@ -38,6 +38,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
+Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Gibraltar/Gibraltar.prf
+++ b/UK/Gibraltar/Gibraltar.prf
@@ -38,6 +38,7 @@ Plugins	Plugin2Display1	SMR radar display
 Plugins	Plugin3	\..\Data\Plugin\AfvEuroScopeBridge.dll
 Plugins	Plugin4	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin5	\..\Data\Plugin\VCH.dll
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 LastSession	server	AUTOMATIC
 LastSession	atis_url0	https://www.vatatis.nz/gen?apptype=ILS&arr=$arrrwy($atisairportA)&dep=$deprwy($atisairportA)&metar=$metar($atisairportA)
 LastSession	atis_url1	https://www.vatatis.nz/gen?apptype=ILS&arr=$arrrwy($atisairportB)&dep=$deprwy($atisairportB)&metar=$metar($atisairportB)

--- a/UK/Gibraltar/Gibraltar.prf
+++ b/UK/Gibraltar/Gibraltar.prf
@@ -38,7 +38,7 @@ Plugins	Plugin2Display1	SMR radar display
 Plugins	Plugin3	\..\Data\Plugin\AfvEuroScopeBridge.dll
 Plugins	Plugin4	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin5	\..\Data\Plugin\VCH.dll
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 LastSession	server	AUTOMATIC
 LastSession	atis_url0	https://www.vatatis.nz/gen?apptype=ILS&arr=$arrrwy($atisairportA)&dep=$deprwy($atisairportA)&metar=$metar($atisairportA)
 LastSession	atis_url1	https://www.vatatis.nz/gen?apptype=ILS&arr=$arrrwy($atisairportB)&dep=$deprwy($atisairportB)&metar=$metar($atisairportB)

--- a/UK/Glasgow/Glasgow.prf
+++ b/UK/Glasgow/Glasgow.prf
@@ -35,6 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Glasgow/Glasgow.prf
+++ b/UK/Glasgow/Glasgow.prf
@@ -35,7 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Heathrow/Heathrow.prf
+++ b/UK/Heathrow/Heathrow.prf
@@ -36,6 +36,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
+Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Heathrow/Heathrow.prf
+++ b/UK/Heathrow/Heathrow.prf
@@ -36,7 +36,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
-Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin7	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Isle of Man/Ronaldsway.prf
+++ b/UK/Isle of Man/Ronaldsway.prf
@@ -34,7 +34,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Isle of Man/Ronaldsway.prf
+++ b/UK/Isle of Man/Ronaldsway.prf
@@ -34,6 +34,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Leeds/Leeds.prf
+++ b/UK/Leeds/Leeds.prf
@@ -35,6 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Liverpool/Liverpool.prf
+++ b/UK/Liverpool/Liverpool.prf
@@ -37,6 +37,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Liverpool/Liverpool.prf
+++ b/UK/Liverpool/Liverpool.prf
@@ -37,7 +37,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Manchester/Manchester.prf
+++ b/UK/Manchester/Manchester.prf
@@ -34,7 +34,7 @@ Plugins	Plugin2	\..\Data\Plugin\AfvEuroScopeBridge.dll
 Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
-Plugins Plugin6 \..\Data\Plugin\CDM
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt

--- a/UK/Manchester/Manchester.prf
+++ b/UK/Manchester/Manchester.prf
@@ -34,6 +34,7 @@ Plugins	Plugin2	\..\Data\Plugin\AfvEuroScopeBridge.dll
 Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
+Plugins Plugin6 \..\Data\Plugin\CDM
 Plugins	Plugin5Display0	Standard ES radar screen
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt

--- a/UK/Newcastle/Newcastle.prf
+++ b/UK/Newcastle/Newcastle.prf
@@ -37,6 +37,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Newcastle/Newcastle.prf
+++ b/UK/Newcastle/Newcastle.prf
@@ -37,7 +37,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Newquay/Newquay.prf
+++ b/UK/Newquay/Newquay.prf
@@ -34,7 +34,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Newquay/Newquay.prf
+++ b/UK/Newquay/Newquay.prf
@@ -34,6 +34,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Norwich/Norwich.prf
+++ b/UK/Norwich/Norwich.prf
@@ -34,7 +34,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Norwich/Norwich.prf
+++ b/UK/Norwich/Norwich.prf
@@ -34,6 +34,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Oxford/Oxford.prf
+++ b/UK/Oxford/Oxford.prf
@@ -35,7 +35,7 @@ Plugins	Plugin2Display1	SMR radar display
 Plugins	Plugin3	\..\Data\Plugin\AfvEuroScopeBridge.dll
 Plugins	Plugin4	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin5	\..\Data\Plugin\VCH.dll
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Oxford/Oxford.prf
+++ b/UK/Oxford/Oxford.prf
@@ -35,6 +35,7 @@ Plugins	Plugin2Display1	SMR radar display
 Plugins	Plugin3	\..\Data\Plugin\AfvEuroScopeBridge.dll
 Plugins	Plugin4	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin5	\..\Data\Plugin\VCH.dll
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Solent/Solent Radar.prf
+++ b/UK/Solent/Solent Radar.prf
@@ -36,6 +36,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 ASRFastKeys	6	\..\Data\ASR\Solent\Bournemouth SMR.asr
 RecentFiles	Recent7	\..\Data\ASR\Solent\Bournemouth SMR.asr
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt

--- a/UK/Solent/Solent Radar.prf
+++ b/UK/Solent/Solent Radar.prf
@@ -36,7 +36,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 ASRFastKeys	6	\..\Data\ASR\Solent\Bournemouth SMR.asr
 RecentFiles	Recent7	\..\Data\ASR\Solent\Bournemouth SMR.asr
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt

--- a/UK/Southend/Southend.prf
+++ b/UK/Southend/Southend.prf
@@ -35,6 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
+Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Southend/Southend.prf
+++ b/UK/Southend/Southend.prf
@@ -35,7 +35,7 @@ Plugins	Plugin3	\..\Data\Plugin\VFPC.dll
 Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NOVA\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
-Plugins Plugin6 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin6	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Thames/Thames.prf
+++ b/UK/Thames/Thames.prf
@@ -40,6 +40,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
+Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt

--- a/UK/Thames/Thames.prf
+++ b/UK/Thames/Thames.prf
@@ -40,7 +40,7 @@ Plugins	Plugin4	\..\Data\Plugin\VCH.dll
 Plugins	Plugin5	\..\Data\Plugin\TopSky_NODE\TopSky.dll
 Plugins	Plugin5Display0	Standard ES radar screen
 Plugins	Plugin6	\..\Data\Plugin\CCDS-R\CCDS-R.dll
-Plugins Plugin7 \..\Data\Plugin\CDM\CDM.dll
+Plugins	Plugin7	\..\Data\Plugin\CDM\CDM.dll
 Settings	airlines	\..\Data\Datafiles\ICAO_Airlines.txt
 Settings	airports	\..\Data\Datafiles\ICAO_Airports.txt
 Settings	aircraft	\..\Data\Datafiles\ICAO_Aircraft.txt


### PR DESCRIPTION
Fixes #1047 

# Summary of changes
This change adds CDM to all combined radar profiles, and hides the columns by default.

# Screenshots (if necessary)
This screenshot is replicated across all radar profiles
![image](https://github.com/user-attachments/assets/180c58fe-3375-4171-ae45-5dd4c9c979d7)
