### PR TITLE
Fixes #1057 - Fixed iTEC SI changing frequency near sector boundary

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2025/04 to 2025/05
+x. Bug - Fixed iTEC Sector Indicator changing from controller ID to frequency - thanks to @SamLefevre (Samuel Lefevre)
+
 # Changes from release 2025/03 to 2025/04
 1. Bug - Fixed Biggin Hill Approach (EGKB_A_APP) logon callsign - thanks to @m4ksc (Maks Ciesielski)
 2. Enhancement - Updated vATIS profiles & set up auto-updating - thanks to @BenWalker01 (Ben Walker)

--- a/UK/Data/Settings/Tags.txt
+++ b/UK/Data/Settings/Tags.txt
@@ -1662,7 +1662,7 @@ TAGITEM:1::0:0:0:0::0:0:::1
 TAGITEM:22::1:0:8:39:TopSky plugin:0:1::TopSky plugin:0
 TAGITEM:58::0:1:32:0:TopSky plugin:0:1:::1
 TAGITEM:101::0:1:0:0:UK Controller Plugin:0:1:::1
-TAGITEM:26::0:1:0:0::0:1:::0
+TAGITEM:64::0:1:0:0::0:1:::0
 TAGITEM:0::0:0:0:0::0:1:::1
 TAGITEM:4::0:0:0:0::0:1:::1
 TAGITEM:3::0:0:0:0::0:1:::1
@@ -1681,7 +1681,7 @@ TAGITEM:33::0:0:0:0::0:0:::1
 TAGITEM:22::1:0:6:39:TopSky plugin:0:1:TopSky plugin:TopSky plugin:8
 TAGITEM:58::0:1:32:0:TopSky plugin:0:1:::1
 TAGITEM:101::0:1:0:0:UK Controller Plugin:0:1:::1
-TAGITEM:26::0:1:20:42::0:1::TopSky plugin:8
+TAGITEM:64::0:1:20:42::0:1::TopSky plugin:8
 TAGITEM:0::0:0:0:0::0:1:::1
 TAGITEM:4::0:0:0:0::0:1:::1
 TAGITEM:3::0:0:0:0::0:1:::1
@@ -1729,7 +1729,7 @@ TAGITEM:1::0:0:0:0::0:0:::1
 TAGITEM:22::1:0:8:39:TopSky plugin:0:1::TopSky plugin:0
 TAGITEM:58::0:1:32:0:TopSky plugin:0:1:::1
 TAGITEM:101::0:1:0:0:UK Controller Plugin:0:1:::1
-TAGITEM:26::0:1:0:0::0:1:::0
+TAGITEM:64::0:1:0:0::0:1:::0
 TAGITEM:0::0:0:0:0::0:1:::1
 TAGITEM:4::0:0:0:0::0:1:::1
 TAGITEM:3::0:0:0:0::0:1:::1
@@ -1819,7 +1819,7 @@ TAGITEM:33::0:0:0:0::0:0:::1
 TAGITEM:22::1:0:6:39:TopSky plugin:0:1:TopSky plugin:TopSky plugin:8
 TAGITEM:58::0:1:32:0:TopSky plugin:0:1:::1
 TAGITEM:101::0:1:0:0:UK Controller Plugin:0:1:::1
-TAGITEM:26::0:1:20:42::0:1::TopSky plugin:8
+TAGITEM:64::0:1:20:42::0:1::TopSky plugin:8
 TAGITEM:0::0:0:0:0::0:1:::1
 TAGITEM:4::0:0:0:0::0:1:::1
 TAGITEM:3::0:0:0:0::0:1:::1


### PR DESCRIPTION
Fixes #1057 

# Summary of changes

Uses the 'Unchangable' variant of ES sector indicator to prevent the SI switching from controller ID to controller frequency.

# Screenshots (if necessary)

N/A
