### PR TITLE
Add missing markdown title formatting to Contributing.md

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -5,7 +5,7 @@ Welcome to the UK Controller Pack repository. Thank you for your interest in con
 ## Contributor license agreement
 
 By submitting code as an individual, you agree that VATSIM UK can use your amendments, fixes, patches, changes, modifications, submissions and creations in the production of the UK Controller Pack and that the ownership of your submissions transfers to VATSIM UK in their entirety.
-Helping others
+## Helping others
 
 Please help other users wherever you can (everybody starts somewhere). If you require assistance (or wish to provide additional assistance) you can find our contributors in the VATSIM UK Discord.
 


### PR DESCRIPTION
# Summary of changes

The title for the 'Helping others' section in Contributing.md was not formatted as a title in markdown.
Formatted the 'Helping others' section title with `##` prior.

Given the minor nature, and that it is only to development documentation, I would like to forgo a changelog entry, except if necessary otherwise.