### PR TITLE
Rename duplicate .08benbo alias.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 1. AIRAC (2504) - Updated Halton (EGWN) frequency - thanks to @Liaely (Lily Unitt)
 2. Bug - Fixed iTEC Sector Indicator changing from controller ID to frequency - thanks to @SamLefevre (Samuel Lefevre)
 3. Enhancement - Incorporated CDM Plugin 2.2.6 - thanks to @luke11brown (Luke Brown)
+4. Bug - Fixed duplicate .08benbo alias - thanks to @ThomasSaunders (Thomas Saunders)
 
 # Changes from release 2025/03 to 2025/04
 1. Bug - Fixed Biggin Hill Approach (EGKB_A_APP) logon callsign - thanks to @m4ksc (Maks Ciesielski)

--- a/UK/Data/Alias/AC_Alias.txt
+++ b/UK/Data/Alias/AC_Alias.txt
@@ -136,7 +136,7 @@ Departure
 .08sam IMVUR N63 SAM then as filed
 .26kenet NOVMA L620 NIBDA N14 VOUGA then as filed
 .08kenet IMVUR N63 VOUGA then as filed
-.08benbo BOGNA L612 BENBO then as filed
+.26benbo BOGNA L612 BENBO then as filed
 .08benbo SFD Y47 BENBO then as filed
 .08xidil SFD M605 then as filed
 


### PR DESCRIPTION
Fixes #1063 

# Summary of changes

I updated alias.txt to remove the duplication using appropriate names based on previous conventions. I tested it and it is working on my Euroscope setup.
