### PR TITLE
Fixes #1070 - Automations: Changelog change check script runs unnecessarily

### DIFF
--- a/.github/workflows/Changelog Police.yml
+++ b/.github/workflows/Changelog Police.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   changelog-check:
-    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'no-changelog') }} # Check for no-changelog label
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Fixes #1070 

# Summary of changes

Removes action trigger for change to pull request title, description, or base branch.
Adds exclusion for when a pull request is labeled 'no-changelog'.

Changelog omitted, reasoning as with [#5625](https://github.com/VATSIM-UK/UK-Sector-File/pull/5625)
