### PR TITLE
Fixes #1106 - Correct Gibraltar Profile vSMR airport setting

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 1. AIRAC (2506) - Updated Glasgow (EGPF) radar and ATIS frequencies - thanks to @Liaely (Lily Unitt)
 2. AIRAC (2506) - Updated Inverness (EGPE) TopSky minimum altitudes - thanks to @Liaely (Lily Unitt)
 3. AIRAC (2506) - Removed Inverness Approach (EGPE_A_APP) - thanks to @Liaely (Lily Unitt)
+4. Bug - Corrected vSMR settings for Gibraltar (LXGB) SMR - thanks to @Liaely (Lily Unitt)
 
 # Changes from release 2025/04 to 2025/05
 1. AIRAC (2504) - Updated Halton (EGWN) frequency - thanks to @Liaely (Lily Unitt)

--- a/UK/Data/ASR/Gibraltar/Gibraltar SMR.asr
+++ b/UK/Data/ASR/Gibraltar/Gibraltar SMR.asr
@@ -80,4 +80,4 @@ PLUGIN:UK Controller Plugin:wakeCalculatorCollapsed:0
 PLUGIN:UK Controller Plugin:wakeCalculatorVisibility:0
 PLUGIN:UK Controller Plugin:wakeCalculatorXPosition:200
 PLUGIN:UK Controller Plugin:wakeCalculatorYPosition:200
-PLUGIN:vSMR:Airport:LXGB
+PLUGIN:vSMR Vatsim UK:Airport:LXGB


### PR DESCRIPTION
Fixes #1106 

# Summary of changes

Fixes vSMR setting for Gibraltar (LXGB) to properly display LXGB in the top-left corner for vSMR and all consequential effects.

# Screenshots (if necessary)

Before:
![image](https://github.com/user-attachments/assets/e1f9cb5b-3aa3-4666-b40e-b4369e550e45)

After:
![image](https://github.com/user-attachments/assets/ea03a3ea-6014-4d7e-90a7-3ce66afccdb5)
