### PR TITLE
Fixes #1112 - Remove Peterborough/Conington (EGSF) ATZ from ASRs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,7 @@
 3. AIRAC (2506) - Removed Inverness Approach (EGPE_A_APP) - thanks to @Liaely (Lily Unitt)
 4. Bug - Corrected vSMR settings for Gibraltar (LXGB) SMR - thanks to @Liaely (Lily Unitt)
 5. AIRAC (2506) - Update Heathrow (EGLL) planner frequency for 8.33 kHz channels - thanks to @Liaely (Lily Unitt)
+6. AIRAC (2506) - Removed Peterborough/Conington (EGSF) ATZ from ASRs - thanks to @matthew4301 (Matthew Stothard)
 
 # Changes from release 2025/04 to 2025/05
 1. AIRAC (2504) - Updated Halton (EGWN) frequency - thanks to @Liaely (Lily Unitt)

--- a/UK/Data/ASR/FID/FID.asr
+++ b/UK/Data/ASR/FID/FID.asr
@@ -382,7 +382,6 @@ ARTCC low boundary:EGPT Perth ATZ:
 ARTCC low boundary:EGPU Tiree ATZ:
 ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Farnborough/Farnborough Radar_1.asr
+++ b/UK/Data/ASR/Farnborough/Farnborough Radar_1.asr
@@ -162,7 +162,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Farnborough/Farnborough Radar_2.asr
+++ b/UK/Data/ASR/Farnborough/Farnborough Radar_2.asr
@@ -386,7 +386,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Farnborough/Farnborough Radar_3.asr
+++ b/UK/Data/ASR/Farnborough/Farnborough Radar_3.asr
@@ -386,7 +386,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Farnborough/Farnborough Radar_4.asr
+++ b/UK/Data/ASR/Farnborough/Farnborough Radar_4.asr
@@ -661,7 +661,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Newquay/Newquay Radar_1.asr
+++ b/UK/Data/ASR/Newquay/Newquay Radar_1.asr
@@ -388,7 +388,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Newquay/Newquay Radar_2.asr
+++ b/UK/Data/ASR/Newquay/Newquay Radar_2.asr
@@ -388,7 +388,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Newquay/Newquay Radar_3.asr
+++ b/UK/Data/ASR/Newquay/Newquay Radar_3.asr
@@ -388,7 +388,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Newquay/Newquay Radar_4.asr
+++ b/UK/Data/ASR/Newquay/Newquay Radar_4.asr
@@ -614,7 +614,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Norwich/Norwich Radar_1.asr
+++ b/UK/Data/ASR/Norwich/Norwich Radar_1.asr
@@ -164,7 +164,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Norwich/Norwich Radar_2.asr
+++ b/UK/Data/ASR/Norwich/Norwich Radar_2.asr
@@ -164,7 +164,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Norwich/Norwich Radar_3.asr
+++ b/UK/Data/ASR/Norwich/Norwich Radar_3.asr
@@ -164,7 +164,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:

--- a/UK/Data/ASR/Norwich/Norwich Radar_4.asr
+++ b/UK/Data/ASR/Norwich/Norwich Radar_4.asr
@@ -164,7 +164,6 @@ ARTCC low boundary:EGQL Leuchars MATZ:
 ARTCC low boundary:EGQS Lossiemouth ATZ:
 ARTCC low boundary:EGQS Lossiemouth MATZ:
 ARTCC low boundary:EGSC Cambridge ATZ:
-ARTCC low boundary:EGSF Peterborough/Conington ATZ:
 ARTCC low boundary:EGSG Stapleford ATZ:
 ARTCC low boundary:EGSH Norwich CTA:
 ARTCC low boundary:EGSL Andrewsfield ATZ/LFA:


### PR DESCRIPTION
Fixes #[issue_no]

# Summary of changes

Removed mentions of EGSF ATZ from:
- Norwich Radar_1.asr
- Norwich Radar_2.asr
- Norwich Radar_3.asr
- Norwich Radar_4.asr
- Newquay Radar_1.asr
- Newquay Radar_2.asr
- Newquay Radar_3.asr
- Newquay Radar_4.asr
- Farnborough Radar_1.asr
- Farnborough Radar_2.asr
- Farnborough Radar_3.asr
- Farnborough Radar_4.asr
- FID.asr