### PR TITLE
Fixes #1167 - FID display opens on wrong screen

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,7 @@
 4. Enhancement - Clarified default settings in configurator - thanks to @clc0609 (Coby Chapman)
 5. Enhancement - Updated CDM plugin to latest version - thanks to @clc0609 (Coby Chapman)
 6. Bug - Removed display of flight plan tracks on ATMs by default - thanks to @Liaely (Lily Unitt)
-7. Bug - Corrected FID default screen - thanks to @Liaely (Lily Unitt)
+7. Bug - Corrected FID default opening screen - thanks to @Liaely (Lily Unitt)
 
 # Changes from release 2025/05 to 2025/06
 1. AIRAC (2506) - Updated Glasgow (EGPF) radar and ATIS frequencies - thanks to @Liaely (Lily Unitt)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,7 @@
 4. Enhancement - Clarified default settings in configurator - thanks to @clc0609 (Coby Chapman)
 5. Enhancement - Updated CDM plugin to latest version - thanks to @clc0609 (Coby Chapman)
 6. Bug - Removed display of flight plan tracks on ATMs by default - thanks to @Liaely (Lily Unitt)
+7. Bug - Corrected FID default screen - thanks to @Liaely (Lily Unitt)
 
 # Changes from release 2025/05 to 2025/06
 1. AIRAC (2506) - Updated Glasgow (EGPF) radar and ATIS frequencies - thanks to @Liaely (Lily Unitt)

--- a/UK/Data/Settings/FID/FID_Screen.txt
+++ b/UK/Data/Settings/FID/FID_Screen.txt
@@ -30,7 +30,7 @@ m_ShowTitleMetar:1
 m_ConnectSELtoSIL:1
 m_ConnectDEPtoSEL:0
 m_ConnectSILtoTOP:0
-m_ScreenNumber:1
+m_ScreenNumber:0
 m_ScreenPosition:0
 m_ScreenMaximized:1
 m_ShowTitleSelectedAc:1


### PR DESCRIPTION
Fixes #1167 

# Summary of changes

Set default screen on opening to screen 1 (`m_ScreenNumber:1` -> `m_ScreenNumber:0`).