### PR TITLE
Automations: Fix minor bugs in TopSky data compiler

### DIFF
--- a/workflows/TopSky/compiler.py
+++ b/workflows/TopSky/compiler.py
@@ -66,7 +66,7 @@ def CPDLC():
     CPDLCFiles = ImportFileIndex('CPDLC/')
     Remove('TopSkyCPDLC.txt')
     Construct('CPDLC/', CPDLCFiles, 'TopSkyCPDLC.txt')
-    CopyAll('Hoppie Code.txt', 'TopSkyCPDLChoppieCode.txt')
+    CopyAll('CPDLC/Hoppie Code.txt', 'TopSkyCPDLChoppieCode.txt')
 
 def Maps():
     MapsFiles = ImportFileIndex('Maps/')


### PR DESCRIPTION
# What are the bugs?

1. Currently, when the workflow is triggered, the exclusions debug message will be generated for comments on their own line in `.Index.txt` files rather than its intended use in removing errant entries without a `.` included.
2. There is an incorrect path for the (empty) file of `Hoppie Code.txt`.

# Summary of changes

1. Before the error message is generated, it checks if there is no entry. Prior to this, if there is a comment, it removes the comment (and separator of `//`). If the comment is its own new line, then there is nothing on the line. This generates an errant debug message.
2. Correct path for `Hoppie Code.txt` in compiler script.

Note: As this will not generate a change in the output files the workflow will 'fail', this can be safely ignored.