### PR TITLE
Automations: Exclude non-relevant paths for logon workflow trigger

### DIFF
--- a/.github/workflows/logon-details.yml
+++ b/.github/workflows/logon-details.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - 'main'
+    paths:
+      - 'workflows/logon-details/**'
+      - '.github/workflows/logon-details.yml'
 
 jobs:
   changes:


### PR DESCRIPTION
# What is the current situation?

Currently, when any push happens to main, the workflow triggers to check for changes. This is unneeded for most pushes, which do not affect any potentially relevant paths.

# Summary of changes

Limit workflow trigger to potentially relevant paths only.