### PR TITLE
iTEC symbology colour accuracy

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 6. Enhancement - Update Configurator.exe to set VCCS PTT Key - thanks to @AdriTheDev (Callum Hicks) and @Lucak1011 (Luca Kulaga)
 7. Bug - Corrected EGLC_APP Position Callsign - thanks to @PLM1995 (Peter Mooney)
 8. Enhancement - Updated CDM plugin to latest version - thanks to @clc0609 (Coby Chapman)
+x. Enhancement - Improved iTEC colour accuracy - thanks to @SamLefevre (Samuel Lefevre)
 
 # Changes from release 2025/06 to 2025/07
 1. AIRAC (2507) - Removed danger area EGD206 from TopSky - thanks to @Liaely (Lily Unitt)

--- a/UK/Data/Plugin/TopSky_iTEC/TopSkySettings.txt
+++ b/UK/Data/Plugin/TopSky_iTEC/TopSkySettings.txt
@@ -105,7 +105,7 @@ Color_Active_Sector=192,192,192
 Color_Active_Text_Map=139,0,0
 Color_AIW_Intrusion=255,142,0
 Color_Arm
-Color_Background=195,195,185
+Color_Background=195,195,195
 Color_Border
 Color_BottomShadow
 Color_CARD_Conflict_Number

--- a/UK/Data/Plugin/TopSky_iTEC/TopSkySettings.txt
+++ b/UK/Data/Plugin/TopSky_iTEC/TopSkySettings.txt
@@ -64,7 +64,7 @@ Color_Concerned=0,0,250
 Color_Coordination=0,0,250
 Color_Unconcerned=255,250,250
 Color_Unknown=239,224,42
-Color_Redundant=140,27,138
+Color_Redundant=102,19,100
 
 //Colour settings
 Color_ACF_Via_CFL

--- a/UK/Data/Settings/AC/iTEC_Symbology.txt
+++ b/UK/Data/Settings/AC/iTEC_Symbology.txt
@@ -25,7 +25,7 @@ Runways:extended centerline:8881798:3.5:0:0:7
 Runways:name:8421504:3.5:0:0:7
 Datablock:non concerned:16448255:3.4:0:0:7
 Datablock:notified:16384000:3.4:0:0:7
-Datablock:assumed:6558566:3.4:0:0:7
+Datablock:assumed:0:3.4:0:0:7
 Datablock:transfer to me initiated:0:3.4:0:0:7
 Datablock:redundant:6558566:3.4:0:0:7
 Datablock:information:29670:3.4:0:0:7

--- a/UK/Data/Settings/AC/iTEC_Symbology.txt
+++ b/UK/Data/Settings/AC/iTEC_Symbology.txt
@@ -44,7 +44,7 @@ Datablock:ongoing requested by me:4015580:3.4:0:0:7
 Datablock:ongoing requested by other:4015580:3.4:0:0:7
 Datablock:ongoing accepted:2263842:3.4:0:0:7
 Datablock:ongoing refused:16734792:3.4:0:0:7
-Datablock:detailed background:14342874:3.4:0:0:7
+Datablock:detailed background:14609907:3.4:0:0:7
 Datablock:active item background:13816530:3.4:0:0:7
 Datablock:arrival background:1395241:3.4:0:0:7
 Datablock:departure background:4264977:3.4:0:0:7

--- a/UK/Data/Settings/AC/iTEC_Symbology.txt
+++ b/UK/Data/Settings/AC/iTEC_Symbology.txt
@@ -25,9 +25,9 @@ Runways:extended centerline:8881798:3.5:0:0:7
 Runways:name:8421504:3.5:0:0:7
 Datablock:non concerned:16448255:3.4:0:0:7
 Datablock:notified:16384000:3.4:0:0:7
-Datablock:assumed:0:3.4:0:0:7
+Datablock:assumed:6558566:3.4:0:0:7
 Datablock:transfer to me initiated:0:3.4:0:0:7
-Datablock:redundant:9051020:3.4:0:0:7
+Datablock:redundant:6558566:3.4:0:0:7
 Datablock:information:29670:3.4:0:0:7
 Datablock:even flight level:11974326:3.4:0:0:7
 Datablock:odd flight level:39835:3.4:0:0:7
@@ -97,7 +97,7 @@ Ground Network:taxiway:65280:3.5:0:3:7
 Ground Network:terminal taxiway:255:3.5:0:3:7
 Sector:line:7237230:4.0:0:0:7
 Sector:msaw:32768:2.0:0:2:7
-Sector:active sector background:12303291:3.5:0:0:7
+Sector:active sector background:11908533:3.5:0:0:7
 Sector:inactive sector background:12632256:3.5:0:0:7
 SYMBOL:0
 SYMBOLITEM:MOVETO -3 -3


### PR DESCRIPTION
# Summary of changes

Updated iTEC colours to be more accurate, not sure if I can show the image used but the active sector should be darker, the redundant colour darker as well and the detailed tag should be tinted more yellow.

# Screenshots

<img width="352" height="252" alt="image" src="https://github.com/user-attachments/assets/963ba286-4c2b-4e05-b6e9-e34cd2c79cef" />
<img width="409" height="369" alt="image" src="https://github.com/user-attachments/assets/0a8b7552-c526-4c54-a13d-2d217a583b5f" />
