### PR TITLE
Fixes #1215 - Update Area Minimum Altitude over Jersey

### DIFF
--- a/.data/TopSky Shared/MSAW/AMA/Areas.txt
+++ b/.data/TopSky Shared/MSAW/AMA/Areas.txt
@@ -2,7 +2,7 @@
 //L:Latmin:Lonmin:dLat:dLon:N:MSA1:MSA2:....MSAn
 
 //Channel Islands (49N)
-L:49.0:-3:0.5:0.5:2:1700:1900
+L:49.0:-3:0.5:0.5:2:1700:1800
 L:49.5:-3:0.5:0.5:2:1700:1800
 
 //Scillies (49.30N)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2025/09 to 2025/10
+1. AIRAC (2510) - Updated Area Minimum Altitude over Jersey - thanks to @clc0609 (Coby Chapman)
+
 # Changes from release 2025/08 to 2025/09
 1. Enhancement - Added DiscordEuroscope plugin to controller pack - thanks to @AdriTheDev (Callum Hicks) and @Liaely (Lily Unitt)
 2. Enhancement - V-LARA Military airspace reservation system integrated - thanks to @luke11brown (Luke Brown)


### PR DESCRIPTION
Fixes #1215

# Summary of changes

Updated TopSky MSAW Area Minimum Altitude Jersey (1900 -> 1800).

# Screenshots (if necessary)
