### PR TITLE
Fixes #1406: smarter “changes-only” baseline selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 🏷️ Determine Latest and Major Baseline Release Tags
+      - name: 🏷️ Determine Tags for Latest and Last Release of Interest
         id: tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #1406 

## 🧾 Summary of changes (Release workflow: smarter “changes-only” baseline selection)

### 🏷️ Changes-only ZIP now diffs against the last **major baseline** tag
- Updates `.github/workflows/release.yml` to improve how the **changes-only** pack decides its `from_tag`.
- Previously, it always used:
  - `latest_tag = tags[0]`
  - `previous_tag = tags[1]`
  → meaning it compared against the immediately previous release, even if that release was a **patch/suffix** tag.

- Now it determines:
  - ✅ `latest_tag` as the most recent release tag (unchanged)
  - ✅ `previous_tag` as the most recent **major baseline** release tag *prior* to the current major cycle

### 🧠 How the new baseline logic works
- If `latest_tag` matches a cycle tag with optional suffix (e.g. `YYYY_MM` or `YYYY_MMabc`):
  - Extracts `year` + `cycle` from `latest_tag`
  - Computes a comparable numeric key (`year * 100 + cycle`)
  - Scans older release tags and selects the first tag that is a **pure major tag** (`YYYY_MM`, no suffix) with a **smaller** major key
  - Falls back to `tags[1]` if no suitable baseline is found

### 🧾 Improved logging for debugging
- The workflow now prints which range is being used:
  - `Using changes-only range: <from_tag> -> <latest_tag>`
- This makes it clearer why a particular baseline was chosen in CI logs.

### ✅ Net effect
- The **changes-only ZIP** should now represent changes since the last *major baseline release* (e.g. `2026_02`) instead of changes since the last release (e.g. `2026_02b`), which is especially useful when multiple patch/suffix releases exist within the same cycle.