### PR TITLE
TopSky Compiler - Fix UTC replacement

### DIFF
--- a/workflows/TopSky/compiler.py
+++ b/workflows/TopSky/compiler.py
@@ -150,7 +150,7 @@ def ApplyDaylightSavings(Filename):
     FileData = FileData.replace("UTC(E)", UTCEnd)
     FileData = FileData.replace("DST(S)", DaylightSavingsTimeStart)
     FileData = FileData.replace("DST(E)", DaylightSavingsTimeEnd)
-    FileData = FileData.replace("UTC(E)", UTCStart)
+    FileData = FileData.replace("UTC(S)", UTCStart)
     
     f = open(Filename,'w')
     f.write(FileData)


### PR DESCRIPTION
Whilst the workflow can now run, `UTC(S)` from the raw data is still maintained, where is should not be, and should be replaced by a date.

This fixes a small typo which causes this.

I know how this happened, but I'm surprised how I didn't spot it before now 🤦 