### PR TITLE
Fixes #1479 - EGPF vATIS update

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changes from release 2026/04 to 2026/05
-x. Bug - Added missing EGPF vATIS preset - thanks to @kye-taylor (Kye Taylor)
+1. Bug - Added missing EGPF vATIS preset - thanks to @kye-taylor (Kye Taylor)
 
 1. AIRAC (2604) - Updated AMA in Jersey area - thanks to @JYang365 (John Yang)
 2. Enhancement - Updated NERC symbology to be more realistic - thanks to @spacenano (Samuel Lefevre)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Changes from release 2026/03 to 2026/04
+# Changes from release 2026/04 to 2026/05
+x. Bug - Added missing EGPF vATIS preset - thanks to @kye-taylor (Kye Taylor)
+
 1. AIRAC (2604) - Updated AMA in Jersey area - thanks to @JYang365 (John Yang)
 2. Enhancement - Updated NERC symbology to be more realistic - thanks to @spacenano (Samuel Lefevre)
 3. AIRAC (2603) - Updated EGD218A and EGD218C altitude limits - thanks to @Kishore-Nair (Kishore Ravikumar)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changes from release 2026/04 to 2026/05
 1. Bug - Added missing EGPF vATIS preset - thanks to @kye-taylor (Kye Taylor)
 
+# Changes from release 2026/03 to 2026/04
 1. AIRAC (2604) - Updated AMA in Jersey area - thanks to @JYang365 (John Yang)
 2. Enhancement - Updated NERC symbology to be more realistic - thanks to @spacenano (Samuel Lefevre)
 3. AIRAC (2603) - Updated EGD218A and EGD218C altitude limits - thanks to @Kishore-Nair (Kishore Ravikumar)

--- a/_vATIS/UK - Scottish TMA.json
+++ b/_vATIS/UK - Scottish TMA.json
@@ -185,6 +185,20 @@
           "Notams": null,
           "ArbitraryText": null,
           "Template": "[FACILITY] COM ATIS [ATIS_CODE].\r\n[TIME].\r\nRWY IN USE ^05.\r\n[TL].\r\n[ARPT_COND]\r\n[NOTAMS]\r\n[WX].\r\n[CLOSING]."
+        },
+        {
+          "Name": "RUNWAY 23 (SCL_GTA_CTR)",
+          "AirportConditions": "DEPARTING AIRCRAFT MAKE INITIAL CONTACT WITH SCOTTISH CONTROL ON 124.930.",
+          "Notams": null,
+          "ArbitraryText": null,
+          "Template": "[FACILITY] COM ATIS [ATIS_CODE].\r\n[TIME].\r\nRWY IN USE ^23.\r\n[TL].\r\n[ARPT_COND]\r\n[NOTAMS]\r\n[WX].\r\n[CLOSING]."
+        },
+        {
+          "Name": "RUNWAY 05 (SCL_GTA_CTR)",
+          "AirportConditions": "DEPARTING AIRCRAFT MAKE INITIAL CONTACT WITH SCOTTISH CONTROL ON 124.930.",
+          "Notams": null,
+          "ArbitraryText": null,
+          "Template": "[FACILITY] COM ATIS [ATIS_CODE].\r\n[TIME].\r\nRWY IN USE ^05.\r\n[TL].\r\n[ARPT_COND]\r\n[NOTAMS]\r\n[WX].\r\n[CLOSING]."
         }
       ],
       "contractions": [


### PR DESCRIPTION
Fixes #1479

# Summary of changes

Added missing SCL_GTA_CTR preset for EGPF vATIS.

