### PR TITLE
Fixes #1504: TC BBX EGMC vATIS 05 runway bug

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 6. Enhancement - Updated Stansted (EGSS) vATIS profile for extra realism - Thanks to @AdriTheDev (Callum Hicks)
 7. Bug - Fixed Scottish voice settings for Humber event split frequency
 8. Enhancement - Incorporated CDM 2.28 - thanks to @luke11brown (Luke Brown)
+x. Bug - Fixed Southend (EGMC) runway 05 preset on TC BBX vATIS profile - thanks to @frazerxyz (Frazer Scully)
 
 # Changes from release 2026/03 to 2026/04
 1. AIRAC (2604) - Updated AMA in Jersey area - Thanks to @JYang365 (John Yang)

--- a/_vATIS/UK - TC Bandbox.json
+++ b/_vATIS/UK - TC Bandbox.json
@@ -1422,7 +1422,7 @@
           "Name": "RUNWAY 05 (LTC_CTR)",
           "AirportConditions": "ILS APPROACH TO BE EXPECTED. DEPARTING AIRCRAFT MAKE INITIAL CONTACT WITH LONDON CONTROL ON 135.805",
           "ArbitraryText": null,
-          "Template": "[FACILITY] COM ATIS [ATIS_CODE].\r\n[TIME].\r\nRWY IN USE ^06.\r\n[TL].\r\n[ARPT_COND]\r\n[NOTAMS]\r\n[WX].\r\n[CLOSING]."
+          "Template": "[FACILITY] COM ATIS [ATIS_CODE].\r\n[TIME].\r\nRWY IN USE ^05.\r\n[TL].\r\n[ARPT_COND]\r\n[NOTAMS]\r\n[WX].\r\n[CLOSING]."
         }
       ],
       "contractions": [


### PR DESCRIPTION
Fixes #1504

# Summary of changes

Changed "06" to "05". Did a scan of the rest of the profiles, couldn't find other instances. 
