### PR TITLE
Fixes #1495: Add vSMR acknowledged QNH to ATM lists

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 6. Enhancement - Updated Stansted (EGSS) vATIS profile for extra realism - Thanks to @AdriTheDev (Callum Hicks)
 7. Bug - Fixed Scottish voice settings for Humber event split frequency
 8. Enhancement - Incorporated CDM 2.28 - thanks to @luke11brown (Luke Brown)
+X. Enhancement - Added vSMR acknowledged QNH item to ATM lists - thanks to @frazerxyz (Frazer Scully)
 
 # Changes from release 2026/03 to 2026/04
 1. AIRAC (2604) - Updated AMA in Jersey area - Thanks to @JYang365 (John Yang)

--- a/UK/Data/Settings/ATM/ATM_Lists.txt
+++ b/UK/Data/Settings/ATM/ATM_Lists.txt
@@ -91,6 +91,7 @@ m_Column:SID:7:0:56:17:17:1::::4:0.0
 m_Column:RWY:3:1:47:19:19:1::::4:0.0
 m_Column:ALT:4:1:20:11:9002:1:::UK Controller Plugin:4:0.0
 m_Column:ASSR:5:1:60:9000:9022:1::UK Controller Plugin:UK Controller Plugin:0:0.0
+m_Column:QNH:4:1:451:551:552:1:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:0:0.0
 m_Column:C:1:1:58:27:0:1::::4:0.0
 m_Column:DCL:3:1:444:544:544:1:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:4:0.0
 m_Column:NFREQ:7:0:107:0:0:0:UK Controller Plugin:::1:0.0
@@ -179,6 +180,7 @@ m_Column:SID:7:0:56:17:17:1::::4:0.0
 m_Column:RWY:3:1:47:19:19:1::::4:0.0
 m_Column:Alt:4:1:20:11:9002:1:::UK Controller Plugin:4:0.0
 m_Column:ASSR:5:1:60:9000:9022:1::UK Controller Plugin:UK Controller Plugin:0:0.0
+m_Column:QNH:4:1:451:551:552:1:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:0:0.0
 m_Column:C:1:1:58:27:0:1::::4:0.0
 m_Column:DCL:3:1:444:544:544:1:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:4:0.0
 m_Column:PRE:3:1:127:9017:9018:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
@@ -207,6 +209,7 @@ m_Column:ADES:4:1:17:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:SID:7:0:56:17:17:1::::4:0.0
 m_Column:RWY:3:1:47:19:19:0::::4:0.0
 m_Column:ASSR:5:1:60:9000:9022:0::UK Controller Plugin:UK Controller Plugin:0:0.0
+m_Column:QNH:4:1:451:551:552:1:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:0:0.0
 m_Column:RLS:3:1:124:9012:9015:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column::6:0:125:9014:9014:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column:PRE:3:1:127:9017:9018:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
@@ -237,6 +240,7 @@ m_Column:ADES:4:1:17:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:SID:7:0:56:17:17:1::::4:0.0
 m_Column:RWY:3:1:47:19:19:0::::4:0.0
 m_Column:CFL:4:1:20:11:9002:0:::UK Controller Plugin:4:0.0
+m_Column:QNH:4:1:451:551:552:1:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:0:0.0
 m_Column:RLS:3:1:124:9012:9015:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column::6:0:125:9014:9014:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column:PRE:3:1:127:9017:9018:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0

--- a/UK/Data/Settings/ATM/ATM_Lists_RECAT.txt
+++ b/UK/Data/Settings/ATM/ATM_Lists_RECAT.txt
@@ -88,6 +88,7 @@ m_Column:SID:7:0:56:17:17:1::::4:0.0
 m_Column:RWY:3:1:47:19:19:1::::4:0.0
 m_Column:Alt:4:1:20:11:0:1::::4:0.0
 m_Column:ASSR:5:1:60:9000:9022:1::UK Controller Plugin:UK Controller Plugin:0:0.0
+m_Column:QNH:4:1:451:551:552:1:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:0:0.0
 m_Column:C:1:1:58:27:0:1::::4:0.0
 m_Column:DCL:3:0:444:544:544:0:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:1:0.0
 m_Column:RFL:4:1:22:30:30:1::::3:0.0
@@ -210,6 +211,7 @@ m_Column:SID:7:0:56:17:17:1::::4:0.0
 m_Column:RWY:3:1:47:19:19:1::::4:0.0
 m_Column:Alt:4:1:20:11:9002:1:::UK Controller Plugin:4:0.0
 m_Column:ASSR:5:1:60:9000:9022:1::UK Controller Plugin:UK Controller Plugin:0:0.0
+m_Column:QNH:4:1:451:551:552:1:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:0:0.0
 m_Column:C:1:1:58:27:0:1::::4:0.0
 m_Column:DCL:3:1:444:544:544:1:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:4:0.0
 END
@@ -237,6 +239,7 @@ m_Column:ADES:4:1:17:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:SID:7:0:56:17:17:1::::4:0.0
 m_Column:RWY:3:1:47:19:19:0::::4:0.0
 m_Column:ASSR:5:1:60:9000:9022:0::UK Controller Plugin:UK Controller Plugin:0:0.0
+m_Column:QNH:4:1:451:551:552:1:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:0:0.0
 m_Column:RLS:3:1:124:9012:9015:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column::6:0:125:9014:9014:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column:PRE:3:1:127:9017:9018:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
@@ -267,6 +270,7 @@ m_Column:ADES:4:1:17:7:9004:1:::UK Controller Plugin:3:0.0
 m_Column:SID:7:0:56:17:17:1::::4:0.0
 m_Column:RWY:3:1:47:19:19:0::::4:0.0
 m_Column:CFL:4:1:20:11:9002:0:::UK Controller Plugin:4:0.0
+m_Column:QNH:4:1:451:551:552:1:vSMR Vatsim UK:vSMR Vatsim UK:vSMR Vatsim UK:0:0.0
 m_Column:RLS:3:1:124:9012:9015:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column::6:0:125:9014:9014:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0
 m_Column:PRE:3:1:127:9017:9018:1:UK Controller Plugin:UK Controller Plugin:UK Controller Plugin:1:0.0

--- a/UK/East Midlands/East Midlands ATM.prf
+++ b/UK/East Midlands/East Midlands ATM.prf
@@ -9,6 +9,9 @@ Settings	SettingsfileDEP	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileFP	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSEL	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSIL	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileSTUP	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileTAXIOUT	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileTAKEOFF	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSYMBOLOGY	\..\Data\Settings\Local\East Midlands\APP_Symbology.txt
 Settings	SettingsfileTAGS	\..\Data\Settings\Tags.txt
 Settings	SettingsfileVCCS	\..\Data\Settings\VCCS_Midlands.txt

--- a/UK/Essex/Luton ATM.prf
+++ b/UK/Essex/Luton ATM.prf
@@ -9,6 +9,9 @@ Settings	SettingsfileDEP	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileFP	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSEL	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSIL	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileSTUP	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileTAXIOUT	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileTAKEOFF	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSYMBOLOGY	\..\Data\Settings\Local\Essex\GW_ATM_Symbology.txt
 Settings	SettingsfileTAGS	\..\Data\Settings\Tags.txt
 Settings	SettingsfileVCCS	\..\Data\Settings\VCCS_South.txt

--- a/UK/Essex/Stansted ATM.prf
+++ b/UK/Essex/Stansted ATM.prf
@@ -9,6 +9,9 @@ Settings	SettingsfileDEP	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileFP	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSEL	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSIL	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileSTUP	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileTAXIOUT	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileTAKEOFF	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSYMBOLOGY	\..\Data\Settings\Local\Essex\SS_ATM_Symbology.txt
 Settings	SettingsfileTAGS	\..\Data\Settings\Tags.txt
 Settings	SettingsfileVCCS	\..\Data\Settings\VCCS_Essex.txt

--- a/UK/Gatwick/Gatwick ATM.prf
+++ b/UK/Gatwick/Gatwick ATM.prf
@@ -9,6 +9,9 @@ Settings	SettingsfileDEP	\..\Data\Settings\ATM\ATM_Lists_RECAT.txt
 Settings	SettingsfileFP	\..\Data\Settings\ATM\ATM_Lists_RECAT.txt
 Settings	SettingsfileSEL	\..\Data\Settings\ATM\ATM_Lists_RECAT.txt
 Settings	SettingsfileSIL	\..\Data\Settings\ATM\ATM_Lists_RECAT.txt
+Settings	SettingsfileSTUP	\..\Data\Settings\ATM\ATM_Lists_RECAT.txt
+Settings	SettingsfileTAXIOUT	\..\Data\Settings\ATM\ATM_Lists_RECAT.txt
+Settings	SettingsfileTAKEOFF	\..\Data\Settings\ATM\ATM_Lists_RECAT.txt
 Settings	SettingsfileSYMBOLOGY	\..\Data\Settings\Local\Gatwick\KK_ATM_Symbology.txt
 Settings	SettingsfileTAGS	\..\Data\Settings\Local\Gatwick\KK_ATM_Tags.txt
 Settings	SettingsfileVCCS	\..\Data\Settings\VCCS_South.txt

--- a/UK/Liverpool/Liverpool ATM.prf
+++ b/UK/Liverpool/Liverpool ATM.prf
@@ -9,6 +9,9 @@ Settings	SettingsfileDEP	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileFP	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSEL	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSIL	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileSTUP	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileTAXIOUT	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileTAKEOFF	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSYMBOLOGY	\..\Data\Settings\Local\Liverpool\ATM_Symbology.txt
 Settings	SettingsfileTAGS	\..\Data\Settings\Tags.txt
 Settings	SettingsfileVCCS	\..\Data\Settings\VCCS_North.txt

--- a/UK/Manchester/Manchester ATM.prf
+++ b/UK/Manchester/Manchester ATM.prf
@@ -9,6 +9,9 @@ Settings	SettingsfileDEP	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileFP	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSEL	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSIL	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileSTUP	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileTAXIOUT	\..\Data\Settings\ATM\ATM_Lists.txt
+Settings	SettingsfileTAKEOFF	\..\Data\Settings\ATM\ATM_Lists.txt
 Settings	SettingsfileSYMBOLOGY	\..\Data\Settings\Local\Manchester\ATM_Symbology.txt
 Settings	SettingsfileTAGS	\..\Data\Settings\Tags.txt
 Settings	SettingsfileVCCS	\..\Data\Settings\VCCS_North.txt


### PR DESCRIPTION
Fixes #1495

# Summary of changes

Added QNH to ATM lists. STUP, TAXIOUT & TAKEOFF list setting files weren't referenced in the profiles, this was also fixed.

# Screenshots (if necessary)
<img width="1267" height="1014" alt="image" src="https://github.com/user-attachments/assets/0272fadd-cfb8-46fd-b77d-c431f81807f5" />
