### PR TITLE
Hide vccs mini control

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changes from release 2026/07 to 2026/07a
 1. Bug - Removed VCH CTL column to prevent conflict with UKCP stand allocation - thanks to @frazerxyz (Frazer Scully)
 2. Enhancement - Added Lydd (EGMD) to AC South vATIS profile - thanks to @frazerxyz (Frazer Scully)
+3. Enhancement - Hid VCCS mini control - thanks to @frazerxyz (Frazer Scully)
 
 # Changes from release 2026/05 to 2026/07
 1. AIRAC (2606) - Updated Belfast EGAC Approach frequencies 8.33khz - thanks to @Harshit-Lalwani (Harshit Lalwani)
@@ -12,7 +13,6 @@
 7. Procedure Change (2607) - Updated Maastricht (EDYY) KOKSY CPDLC logon code - thanks to @Liaely (Lily Unitt)
 8. AIRAC (2607) - Updated Leuchars (EGQL) Approach positions - thanks to @Liaely (Lily Unitt)
 9. Bug - Fixed airport conditions not showing on Luton (EGGW) vATIS profile - thanks to @AdriTheDev (Callum Hicks)
-x. Enhancement - Hid VCCS mini control - thanks to @frazerxyz (Frazer Scully)
 
 # Changes from release 2026/04a to 2026/05
 1. Amendment - Removed UK vFPC whilst allowing for simple loading by those who choose to do so

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,7 @@
 7. Procedure Change (2607) - Updated Maastricht (EDYY) KOKSY CPDLC logon code - thanks to @Liaely (Lily Unitt)
 8. AIRAC (2607) - Updated Leuchars (EGQL) Approach positions - thanks to @Liaely (Lily Unitt)
 9. Bug - Fixed airport conditions not showing on Luton (EGGW) vATIS profile - thanks to @AdriTheDev (Callum Hicks)
+x. Enhancement - Hid VCCS mini control - thanks to @frazerxyz (Frazer Scully)
 
 # Changes from release 2026/04a to 2026/05
 1. Amendment - Removed UK vFPC whilst allowing for simple loading by those who choose to do so

--- a/UK/Data/Settings/Screen.txt
+++ b/UK/Data/Settings/Screen.txt
@@ -52,7 +52,7 @@ m_ShowTooltips:0
 m_OnTheGroundAltitude:5000
 m_OnTheGroundSpeed:50
 m_ShowCdtOnCflCheck:1
-m_ShowTsVccsMiniControl:1
+m_ShowTsVccsMiniControl:0
 ScenarioEditorX:0
 ScenarioEditorY:0
 m_ShowSTARControllers:1

--- a/UK/Data/Settings/Screen_SMR.txt
+++ b/UK/Data/Settings/Screen_SMR.txt
@@ -52,7 +52,7 @@ m_ShowTooltips:0
 m_OnTheGroundAltitude:5000
 m_OnTheGroundSpeed:50
 m_ShowCdtOnCflCheck:0
-m_ShowTsVccsMiniControl:1
+m_ShowTsVccsMiniControl:0
 ScenarioEditorX:0
 ScenarioEditorY:0
 m_ShowSTARControllers:1


### PR DESCRIPTION
# Summary of changes

Hid VCCS mini control in screen settings
<img width="448" height="104" alt="image" src="https://github.com/user-attachments/assets/5ba4f624-afbf-4287-a658-82325e22e76e" />
