### PR TITLE
Remove VCH CTL column to prevent conflict with UKCP stands

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2026/07 to 2026/07a
+1. Bug - Removed VCH CTL column to prevent conflict with UKCP stand allocation - thanks to @frazerxyz (Frazer Scully)
+
 # Changes from release 2026/05 to 2026/07
 1. AIRAC (2606) - Updated Belfast EGAC Approach frequencies 8.33khz - thanks to @Harshit-Lalwani (Harshit Lalwani)
 2. Amendment - Removed display and loading of CDM pending trials
@@ -8,7 +11,6 @@
 7. Procedure Change (2607) - Updated Maastricht (EDYY) KOKSY CPDLC logon code - thanks to @Liaely (Lily Unitt)
 8. AIRAC (2607) - Updated Leuchars (EGQL) Approach positions - thanks to @Liaely (Lily Unitt)
 9. Bug - Fixed airport conditions not showing on Luton (EGGW) vATIS profile - thanks to @AdriTheDev (Callum Hicks)
-x. Bug - Removed VCH CTL column to prevent conflict with UKCP stand allocation - thanks to @frazerxyz (Frazer Scully)
 
 # Changes from release 2026/04a to 2026/05
 1. Amendment - Removed UK vFPC whilst allowing for simple loading by those who choose to do so

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,7 @@
 7. Procedure Change (2607) - Updated Maastricht (EDYY) KOKSY CPDLC logon code - thanks to @Liaely (Lily Unitt)
 8. AIRAC (2607) - Updated Leuchars (EGQL) Approach positions - thanks to @Liaely (Lily Unitt)
 9. Bug - Fixed airport conditions not showing on Luton (EGGW) vATIS profile - thanks to @AdriTheDev (Callum Hicks)
+x. Bug - Removed VCH CTL column to prevent conflict with UKCP stand allocation - thanks to @frazerxyz (Frazer Scully)
 
 # Changes from release 2026/04a to 2026/05
 1. Amendment - Removed UK vFPC whilst allowing for simple loading by those who choose to do so

--- a/UK/Data/Settings/AC/AC_General.txt
+++ b/UK/Data/Settings/AC/AC_General.txt
@@ -176,7 +176,6 @@ m_OrderingColumn:1
 m_HeaderOnly:0
 m_Column:RUNW:4:1:47:19:19:1::::1:0.0
 m_Column:CALLSIGN:9:0:9:8:0:1::::0:0.0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:0:0:0:VCH:::0:0.0

--- a/UK/Data/Settings/ATM/ATM_Lists.txt
+++ b/UK/Data/Settings/ATM/ATM_Lists.txt
@@ -108,7 +108,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:548:0:0:VCH:VCH::0:0.0

--- a/UK/Data/Settings/ATM/ATM_Lists_RECAT.txt
+++ b/UK/Data/Settings/ATM/ATM_Lists_RECAT.txt
@@ -104,7 +104,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:548:0:0:VCH:VCH::0:0.0
@@ -285,7 +284,6 @@ m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
 m_Column:RUNW:4:1:47:19:19:1::::1:0.0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:548:0:0:VCH:VCH::0:0.0

--- a/UK/Data/Settings/FID/FID_Lists.txt
+++ b/UK/Data/Settings/FID/FID_Lists.txt
@@ -73,7 +73,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:0:0:0:VCH:::0:0.0
@@ -222,7 +221,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:0:0:0:VCH:::0:0.0

--- a/UK/Data/Settings/Lists.txt
+++ b/UK/Data/Settings/Lists.txt
@@ -109,7 +109,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:548:0:0:VCH:VCH::0:0.0

--- a/UK/Data/Settings/Lists_Area.txt
+++ b/UK/Data/Settings/Lists_Area.txt
@@ -100,7 +100,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:548:0:0:VCH:VCH::0:0.0
@@ -130,7 +129,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:TYPE:6:1:88:0:36:1::::1:0.0
 m_Column:C/S:7:0:9:0:36:1::::0:0.0
 m_Column:C/S:7:0:85:0:36:1::::1:0.0

--- a/UK/Data/Settings/Lists_RECAT.txt
+++ b/UK/Data/Settings/Lists_RECAT.txt
@@ -107,7 +107,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:548:0:0:VCH:VCH::0:0.0

--- a/UK/Data/Settings/Lists_SMR.txt
+++ b/UK/Data/Settings/Lists_SMR.txt
@@ -107,7 +107,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:548:0:0:VCH:VCH::0:0.0

--- a/UK/Data/Settings/Lists_SMR_RECAT.txt
+++ b/UK/Data/Settings/Lists_SMR_RECAT.txt
@@ -103,7 +103,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:548:0:0:VCH:VCH::0:0.0
@@ -284,7 +283,6 @@ m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
 m_Column:RUNW:4:1:47:19:19:1::::1:0.0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:548:0:0:VCH:VCH::0:0.0

--- a/UK/Data/Settings/Lists_TopSky.txt
+++ b/UK/Data/Settings/Lists_TopSky.txt
@@ -99,7 +99,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:0:0:0:VCH:::0:0.0

--- a/UK/Data/Settings/MPC/MPC_General.txt
+++ b/UK/Data/Settings/MPC/MPC_General.txt
@@ -174,7 +174,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:0:0:0:VCH:::0:0.0

--- a/UK/Data/Settings/SCL/SCL_General.txt
+++ b/UK/Data/Settings/SCL/SCL_General.txt
@@ -174,7 +174,6 @@ m_LineNumber:6
 m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:0:0:0:VCH:::0:0.0

--- a/UK/Data/Settings/TC_APP/TC_APP_General.txt
+++ b/UK/Data/Settings/TC_APP/TC_APP_General.txt
@@ -246,7 +246,6 @@ m_Resizable:0
 m_OrderingColumn:1
 m_HeaderOnly:0
 m_Column:RUNW:4:1:47:19:19:1::::1:0.0
-m_Column:CTL:3:1:640:650:0:0:VCH:VCH::0:0.0
 m_Column:H/S:5:1:440:444:0:0:VCH:VCH::0:0.0
 m_Column:REQ:3:1:540:548:0:0:VCH:VCH::0:0.0
 m_Column:RQT:3:1:544:0:0:0:VCH:::0:0.0


### PR DESCRIPTION
Fixes #1515

# Summary of changes

Removed all instances of the VCH CTL column in list settings files.

# Screenshots
Before
<img width="501" height="360" alt="image" src="https://github.com/user-attachments/assets/2041a73c-2748-4250-b823-064b22724131" />
After
<img width="454" height="340" alt="image" src="https://github.com/user-attachments/assets/a8f56185-f3c3-4666-9e75-1a0cc5d6a19f" />
