### PR TITLE
chore: Bump Slots-Plugin and VACS versions

### DIFF
--- a/.github/badges/Slots-Plugin.json
+++ b/.github/badges/Slots-Plugin.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Slots-Plugin",
-  "message": "v1.10",
+  "message": "v1.1.11",
   "color": "blue"
 }

--- a/.github/badges/VACS.json
+++ b/.github/badges/VACS.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "vacs",
-  "message": "vacs-client-v2.2.0",
+  "message": "vacs-client-v2.5.1",
   "color": "blue"
 }

--- a/.github/dependency_versions.json
+++ b/.github/dependency_versions.json
@@ -16,7 +16,7 @@
   "Slots-Plugin": {
     "schemaVersion": 1,
     "label": "Slots-Plugin",
-    "message": "1.10",
+    "message": "1.1.11",
     "color": "blue",
     "repo": "VATSIMCanada/Slots-Plugin"
   },
@@ -66,7 +66,7 @@
   "VACS": {
     "schemaVersion": 1,
     "label": "VACS",
-    "message": "vacs-client-v2.2.0",
+    "message": "vacs-client-v2.5.1",
     "color": "blue",
     "repo": "vacs-project/vacs"
   }


### PR DESCRIPTION
Fixes #1558 
Fixes #1557 

# Summary of changes

Closes the duplicate dependencies update as these were not updated when the plugins were

