### PR TITLE
Fix TopSky-Incorrect-Push workflow

### DIFF
--- a/.github/workflows/TopSky-Incorrect-Push.yml
+++ b/.github/workflows/TopSky-Incorrect-Push.yml
@@ -3,109 +3,133 @@
 on:
   pull_request:
     types: [opened, synchronize]
-    paths: 
+    paths:
       - 'UK/Data/Plugin/TopSky_NERC/**'
       - 'UK/Data/Plugin/TopSky_NODE/**'
       - 'UK/Data/Plugin/TopSky_NOVA/**'
       - 'UK/Data/Plugin/TopSky_iTEC/**'
+      - 'UK/Data/Plugin/TopSky_MIL/**'
 
 jobs:
   TopSky-Check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      
-      - name: Check if ICAO_Aircraft.json has been edited
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        shell: bash
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/ICAO_Aircraft\.json$'; then
+          git fetch origin
+          echo 'CHANGED_FILES<<EOF' >> "$GITHUB_ENV"
+          git diff --name-only origin/main...HEAD >> "$GITHUB_ENV"
+          echo EOF >> "$GITHUB_ENV"
+
+      - name: Check if ICAO_Aircraft.json has been edited
+        if: ${{ always() }}
+        run: |
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/ICAO_Aircraft\.json$'; then
             echo "ICAO_Aircraft.json has been edited. Please revert the change, and edit .data/TopSky Shared/ICAO_Aircraft.json"
             exit 1
           fi
-     
+
       - name: Check if ICAO_Aircraft.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/ICAO_Aircraft\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/ICAO_Aircraft\.txt$'; then
             echo "ICAO_Aircraft.txt has been edited. Please revert the change, and edit .data/TopSky Shared/ICAO_Aircraft.txt"
             exit 1
           fi
-     
+
       - name: Check if ICAO_Airlines.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/ICAO_Airlines\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/ICAO_Airlines\.txt$'; then
             echo "ICAO_Airlines.txt has been edited. Please revert the change, and edit .data/TopSky Shared/ICAO_Airlines.txt"
             exit 1
           fi
-     
+
       - name: Check if ICAO_Airports.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/ICAO_Airports\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/ICAO_Airports\.txt$'; then
             echo "ICAO_Airports.txt has been edited. Please revert the change, and edit .data/TopSky Shared/ICAO_Airports.txt"
             exit 1
           fi
-     
+
       - name: Check if TopSkyAirspace.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyAirspace\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyAirspace\.txt$'; then
             echo "TopSkyAirspace.txt has been edited. Please revert the change, and edit .data/TopSky Shared/Airspace.txt"
             exit 1
           fi
-     
+
       - name: Check if TopSkyCallsigns.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyCallsigns\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyCallsigns\.txt$'; then
             echo "TopSkyCallsigns.txt has been edited. Please revert the change, and edit .data/TopSky Shared/Callsigns.txt"
             exit 1
           fi
-     
+
       - name: Check if TopSkyCallsignsLocal.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyCallsignsLocal\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyCallsignsLocal\.txt$'; then
             echo "TopSkyCallsignsLocal.txt has been edited. Please revert the change, and edit .data/TopSky Shared/Local Callsigns.txt"
             exit 1
           fi
-      
+
       - name: Check if TopSkyAreas.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyAreas\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyAreas\.txt$'; then
             echo "TopSkyAreas.txt has been edited. Please revert the change, and edit the relevant file in .data/TopSky Shared/Areas/"
             exit 1
           fi
-     
+
       - name: Check if TopSkyCPDLC.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyCPDLC\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyCPDLC\.txt$'; then
             echo "TopSkyCPDLC.txt has been edited. Please revert the change, and edit the relevant file in .data/TopSky Shared/CPDLC/"
             exit 1
           fi
-     
+
       - name: Check if TopSkyCPDLChoppieCode.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyCPDLChoppieCode\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyCPDLChoppieCode\.txt$'; then
             echo "TopSkyCPDLChoppieCode.txt has been edited. Please revert the change, and edit .data/TopSky Shared/CPDLC/Hoppie Code.txt"
             exit 1
           fi
-     
+
       - name: Check if TopSkyMaps.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyMaps\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyMaps\.txt$'; then
             echo "TopSkyMaps.txt has been edited. Please revert the change, and edit the relevant file in .data/TopSky Shared/Maps/"
             exit 1
           fi
-     
+
       - name: Check if TopSkyMSAW.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyMSAW\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyMSAW\.txt$'; then
             echo "TopSkyMSAW.txt has been edited. Please revert the change, and edit the relevant file in .data/TopSky Shared/MSAW/"
             exit 1
           fi
-     
+
       - name: Check if TopSkyRadars.txt has been edited
+        if: ${{ always() }}
         run: |
-          if git diff --name-only origin/main...HEAD | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyRadars\.txt$'; then
+          if echo "$CHANGED_FILES" | grep -E -q '^UK/Data/Plugin/TopSky_((NERC)|(NODE)|(NOVA)|(iTEC)|(MIL))/TopSkyRadars\.txt$'; then
             echo "TopSkyRadars.txt has been edited. Please revert the change, and edit the relevant file in .data/TopSky Shared/Radars/"
             exit 1
           fi
-      
-      - name: No TopSky shared data file improperly edited
+
+      - name: Final output
         run: echo "No TopSky shared data files have been improperly edited."


### PR DESCRIPTION
Partially fixes #1478 

# Summary of changes

Amends the TopSky-Incorrect-Push workflow to correctly validate and test. It now will be able to fail.

# Screenshots

Note: There has since been minor changes to wording, but not to the logic elements since the screenshot was made.

Screenshots taken in a private testing repository.

### Failure example:

<img width="1412" height="1384" alt="image" src="https://github.com/user-attachments/assets/58f055ff-e9ed-4bd5-9cf5-7011db4f7d13" />

### Success example:

<img width="1412" height="1328" alt="image" src="https://github.com/user-attachments/assets/b562587d-a3dc-4e7f-907d-e53b556c746d" />

## Additional information

AI (GitHub Copilot) was used to assist in making these changes (primarily for my own experimentation regarding it 🤔 ); I have tested them and understand them as if I had done them myself.